### PR TITLE
svr4-tools/{star,heirloom-sh}: Minor fixes.

### DIFF
--- a/svr4-tools/3-star.md
+++ b/svr4-tools/3-star.md
@@ -25,9 +25,9 @@ make
 Now install star and supplementary tools as the ***root*** user:
 ```Bash
 install -v -m755 -d /usr/5bin &&
-install -v -m755 star/OBJ/x86_64-linux-gcc/star /usr/5bin &&
-install -v -m755 star_sym/OBJ/x86_64-linux-gcc/star_sym /usr/5bin &&
-install -v -m755 tartest/OBJ/x86_64-linux-gcc/tartest /usr/5bin &&
+install -v -m755 star/OBJ/*/star /usr/5bin &&
+install -v -m755 star_sym/OBJ/*/star_sym /usr/5bin &&
+install -v -m755 tartest/OBJ/*/tartest /usr/5bin &&
 install -v -m755 -d /usr/share/man/5man/man1 &&
 install -v -m644 star/star.1 /usr/share/man/5man/man1 &&
 install -v -m644 star_sym/star_sym.1 /usr/share/man/5man/man1 &&

--- a/svr4-tools/4-heirloom-sh.md
+++ b/svr4-tools/4-heirloom-sh.md
@@ -1,6 +1,6 @@
 [Home](../)
 
-[Prev: star from shilytools](./3-star.md) - [Next: heirloom-doctools](./5-heirloom-doctools.md)
+[Prev: star from schilytools](./3-star.md) - [Next: heirloom-doctools](./5-heirloom-doctools.md)
 
 ***
 


### PR DESCRIPTION
This PR breaks an assumption that the system building star is an amd64 Linux system running gcc and fixes a minor typo in heirloom-sh.