### PR TITLE
Properly fix heirloom-sh (and typo fix in heirloom-ex-vi)

### DIFF
--- a/introduction/changelog.xml
+++ b/introduction/changelog.xml
@@ -40,6 +40,18 @@
     -->
 
     <listitem>
+      <para>February 3rd, 2025</para>
+      <itemizedlist>
+        <listitem>
+          <para>[seal331] - heirloom-sh: Properly fix a glibc 2.34
+          compatibility issue. Fixes
+          <ulink url="&lfs-qol-issues;/17">#17</ulink>.
+          PR <ulink url="&lfs-qol-pull;/42">(#42)</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>February 2nd, 2025</para>
       <itemizedlist>
         <listitem>

--- a/patches/svr4-tools/heirloom-sh/heirloom-sh-050706-glibc234-2.patch
+++ b/patches/svr4-tools/heirloom-sh/heirloom-sh-050706-glibc234-2.patch
@@ -1,0 +1,20 @@
+diff -Naur heirloom-sh-050706/fault.c heirloom-sh-050706-patched/fault.c
+--- heirloom-sh-050706/fault.c	2025-02-03 21:42:16.617468309 +0300
++++ heirloom-sh-050706-patched/fault.c	2025-02-03 22:36:35.184395692 +0300
+@@ -43,7 +43,7 @@
+ #include	<string.h>
+ 
+ static	void (*psig0_func)(int) = SIG_ERR;	/* previous signal handler for signal 0 */
+-static	char sigsegv_stack[SIGSTKSZ];
++char *sigsegv_stack;
+ 
+ static BOOL sleeping = 0;
+ static unsigned char *trapcom[MAXTRAP]; /* array of actions, one per signal */
+@@ -288,6 +288,7 @@
+ 	int rtmax = -1;
+ #endif
+ 
++	sigsegv_stack = sbrk(SIGSTKSZ);
+ 	ss.ss_size = SIGSTKSZ;
+ 	ss.ss_sp = sigsegv_stack;
+ 	ss.ss_flags = 0;

--- a/svr4-tools/heirloom-ex-vi.xml
+++ b/svr4-tools/heirloom-ex-vi.xml
@@ -22,7 +22,7 @@
 
     <para>
       The <application>heirloom-ex-vi</application> package, also known as
-      <quote>The Traditional Vi,</quote> is a portable version of 2.11BSD/SVR4
+      <quote>The Traditional Vi</quote>, is a portable version of 2.11BSD/SVR4
       <application>vi</application>.
     </para>
 

--- a/svr4-tools/heirloom-sh.xml
+++ b/svr4-tools/heirloom-sh.xml
@@ -45,7 +45,7 @@
       <listitem>
         <para>
           Required patch:
-          <ulink url="&patch-root;/svr4-tools/heirloom-sh/heirloom-sh-&heirloom-sh-version;-glibc234.patch"/>
+          <ulink url="&patch-root;/svr4-tools/heirloom-sh/heirloom-sh-&heirloom-sh-version;-glibc234-2.patch"/>
         </para>
       </listitem>
     </itemizedlist>
@@ -72,7 +72,7 @@
       Now, apply a patch to fix the build with glibc 2.34 or newer:
     </para>
 
-<screen><userinput>patch -Np1 -i ../heirloom-sh-&heirloom-sh-version;-glibc234.patch</userinput></screen>
+<screen><userinput>patch -Np1 -i ../heirloom-sh-&heirloom-sh-version;-glibc234-2.patch</userinput></screen>
 
     <para>
       Install <application>heirloom-sh</application> by running the following


### PR DESCRIPTION
This PR properly fixes heirloom-sh.

Fixes #17.

Really needs testing - if someone can suggest a good stress test for POSIX sh, please do!