### PR TITLE
Some documentation bugfixes

### DIFF
--- a/com-emu/freebee.xml
+++ b/com-emu/freebee.xml
@@ -101,8 +101,8 @@ make -C tools</userinput></screen>
       Now, as the &root; user:
     </para>
 
-<screen role="root"><userinput>install -v -Dm755 freebee /usr/bin/freebee &amp;&amp;
-install -v -Dm755 tools/makehdimg /usr/bin/makehdimg &amp;&amp;
+<screen role="root"><userinput>install -v -Dm755 freebee /usr/bin &amp;&amp;
+install -v -Dm755 tools/makehdimg /usr/bin &amp;&amp;
 install -v -m644 freebee.1 /usr/share/man/man1 &amp;&amp;
 install -v -m644 tools/makehdimg.1 /usr/share/man/man1</userinput></screen>
 

--- a/com-emu/idle.xml
+++ b/com-emu/idle.xml
@@ -136,12 +136,8 @@ install -v -Dm755 tools/xprofile_tool/xprofile_tool /usr/bin</userinput></screen
     </para>
 
 <screen role="root"><userinput>install -v -m755 -d /usr/share/idle/bios &amp;&amp;
-install -v -m644 bios/vidstate.rom /usr/share/idle/bios &amp;&amp;
 unzip ../idle_win32_bin.zip &amp;&amp;
-install -v -m644 idle_win32_bin/bios/341-0175-h /usr/share/idle/bios &amp;&amp;
-install -v -m644 idle_win32_bin/bios/341-0176-h /usr/share/idle/bios &amp;&amp;
-install -v -m644 idle_win32_bin/bios/L175REVC.bin /usr/share/idle/bios &amp;&amp;
-install -v -m644 idle_win32_bin/bios/L176REVC.bin /usr/share/idle/bios &amp;&amp;
+install -v -m644 idle_win32_bin/bios/* /usr/share/idle/bios
 rm -rf idle_win32_bin</userinput></screen>
 
   </sect2>
@@ -154,8 +150,7 @@ rm -rf idle_win32_bin</userinput></screen>
       <para>
         If you have not applied the systemwide ROMs patch, you will have to put
         the <filename class="directory">bios/</filename> folder from
-        <filename>idle_win32_bin.zip</filename> with
-        <filename>vidstate.rom</filename> replaced from the source distribution
+        <filename>idle_win32_bin.zip</filename>
         into every folder you plan on executing <application>idle</application>
         from.
       </para>

--- a/com-emu/xhomer.xml
+++ b/com-emu/xhomer.xml
@@ -90,9 +90,9 @@ gcc UTILITIES/venix2xhomer.c -o UTILITIES/venix2xhomer</userinput></screen>
       Now, as the &root; user:
     </para>
 
-<screen role="root"><userinput>install -v -Dm755 xhomer /usr/bin/xhomer &amp;&amp;
-install -v -Dm755 UTILITIES/lbn2xhomer /usr/bin/lbn2xhomer &amp;&amp;
-install -v -Dm755 UTILITIES/venix2xhomer /usr/bin/venix2xhomer</userinput></screen>
+<screen role="root"><userinput>install -v -Dm755 xhomer /usr/bin &amp;&amp;
+install -v -Dm755 UTILITIES/lbn2xhomer /usr/bin &amp;&amp;
+install -v -Dm755 UTILITIES/venix2xhomer /usr/bin</userinput></screen>
 
     <para>
       Optionally, install the documentation as the &root; user:

--- a/introduction/changelog.xml
+++ b/introduction/changelog.xml
@@ -40,6 +40,16 @@
     -->
 
     <listitem>
+      <para>February 26th, 2025</para>
+      <itemizedlist>
+        <listitem>
+          <para>[seal331] - com-emu/{freebee,idle,xhomer}: Simplify install
+          commands. PR <ulink url="&lfs-qol-pull;/61">(#61)</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>February 17th, 2025</para>
       <itemizedlist>
         <listitem>

--- a/svr4-tools/s-nail.xml
+++ b/svr4-tools/s-nail.xml
@@ -147,7 +147,7 @@ ln -svf /usr/5bin/s-nail /usr/ucb/mail</userinput></screen>
             is a symlink pointing to <command>s-nail</command>
           </para>
           <indexterm zone="s-nail ucb-mail">
-            <primary sortas="b-mail">mail</primary>
+            <primary sortas="b-mail">/usr/ucb/mail</primary>
           </indexterm>
         </listitem>
       </varlistentry>


### PR DESCRIPTION
This PR implements the following bugfixes:

A. fixes an index mishap where /usr/ucb/mail is labeled simply "mail" in the index, unlike /usr/5bin/mail
B. simplifies com-emu/idle ROM installation (see the commit message for reasoning)
C. simplifies com-emu/{freebee,xhomer} install commands and makes them consistent with idle (this inconsistency kept me up at night)