### PR TITLE
Socat: Add missing commas in installed programs section

### DIFF
--- a/dev-tools/socat.xml
+++ b/dev-tools/socat.xml
@@ -66,8 +66,8 @@ make</userinput></screen>
           filan,
           procan,
           socat (link to socat1),
-          socat-broker.sh
-          socat-chain.sh
+          socat-broker.sh,
+          socat-chain.sh,
           socat-mux.sh, and
           socat1
         </seg>


### PR DESCRIPTION
Fixes a little formatting oversight (oops).