### PR TITLE
Package updates and fixes

### DIFF
--- a/cde/cde-de.xml
+++ b/cde/cde-de.xml
@@ -65,7 +65,7 @@
       <ulink url="&blfs-svn;/general/libjpeg.html">libjpeg-turbo</ulink>,
       <ulink url="&blfs-svn;/basicnet/libtirpc.html">libtirpc</ulink>,
       <xref linkend="libutempter"/>,
-      <xref linkend="libxp"/>
+      <xref linkend="libxp"/>,
       <ulink url="&blfs-svn;/postlfs/linux-pam.html">Linux-PAM</ulink>,
       <ulink url="&blfs-svn;/server/lmdb.html">lmdb</ulink>,
       <xref linkend="motif"/>,
@@ -149,6 +149,14 @@ install -d -m 755 /usr/lib/systemd/system &amp;&amp;
 install -m 644 contrib/rc/systemd/dtlogin.service /usr/lib/systemd/system/ &amp;&amp;
 systemctl enable dtlogin.service
 </userinput></screen>
+
+      <para revision="sysv">
+        In order to permanently set the default runlevel to 5, starting the
+        <command>dtlogin</command> greeter screen automatically, you can modify
+        <filename>/etc/inittab</filename>. As the &root; user:
+      </para>
+
+<screen role="root" revision="sysv"><userinput>sed /initdefault/s/3/5/ -i /etc/inittab</userinput></screen>
 
     </sect3>
 

--- a/cde/ksh.xml
+++ b/cde/ksh.xml
@@ -52,6 +52,24 @@
 
   </sect2>
 
+  <sect2 role="configuration">
+    <title>Configuring heirloom-sh</title>
+
+    <sect3><title>Configuration Information</title>
+
+      <para>
+        As the &root; user, update <filename>/etc/shells</filename> to include
+        the Korn shell program names:
+      </para>
+
+<screen role="root"><userinput>cat &gt;&gt; /etc/shells &lt;&lt; "EOF"
+<literal>/usr/bin/ksh</literal>
+EOF</userinput></screen>
+
+    </sect3>
+
+  </sect2>
+
   <sect2 role="content">
     <title>Contents</title>
 

--- a/cde/motif.xml
+++ b/cde/motif.xml
@@ -194,7 +194,7 @@ unset YACC</userinput></screen>
           libMrm.so, libUil.so, and libXm.so
         </seg>
         <seg>
-          /usr/include/Mrm, /usr/include/uil, /usr/include/Xm, and
+          /usr/include/Mrm, /usr/include/uil, /usr/include/Xm,
           /usr/etc/X11/mwm, and /usr/share/X11/bindings
         </seg>
       </seglistitem>

--- a/generate-doc-stub.py
+++ b/generate-doc-stub.py
@@ -133,8 +133,9 @@ else:
 			tmp = tmp2
 		else:
 			print(tmp)
-			tmp = '          '
-			tmp2 = tmp2[80:]
+			tmp3 = tmp2.split(', ')
+			tmp = '          ' + tmp3[-2] + ', '
+			tmp2 = ', '.join(tmp3[:-2])
 	print(tmp2, end='')
 	print()
 print('''        </seg>

--- a/generate-doc-stub.py
+++ b/generate-doc-stub.py
@@ -33,7 +33,7 @@ if os.getenv('DOCSTUBGEN_DOCUMENT_LIBRARIES'):
 # OR
 # [<file name>, 'f', 'FILLER']
 
-filelist = [['calprog', 'f'], ['diff3prog', 'f'], ['diffh', 'f']]
+filelist = []
 for d in range(len(sys.argv)):
 	if d == 0 or d == 1:
 		continue

--- a/generate-doc-stub.py
+++ b/generate-doc-stub.py
@@ -33,7 +33,7 @@ if os.getenv('DOCSTUBGEN_DOCUMENT_LIBRARIES'):
 # OR
 # [<file name>, 'f', 'FILLER']
 
-filelist = []
+filelist = [['calprog', 'f'], ['diff3prog', 'f'], ['diffh', 'f']]
 for d in range(len(sys.argv)):
 	if d == 0 or d == 1:
 		continue
@@ -115,8 +115,9 @@ for i in filelist:
 		tmp = tmp2
 	else:
 		print(tmp)
-		tmp = '          '
-		tmp2 = tmp2[80:]
+		tmp3 = tmp2.split(', ')
+		tmp = '          ' + tmp3[-2] + ', '
+		tmp2 = ', '.join(tmp3[:-2])
 print(tmp2, end='')
 print('''
         </seg>

--- a/introduction/changelog.xml
+++ b/introduction/changelog.xml
@@ -40,6 +40,18 @@
     -->
 
     <listitem>
+      <para>March 9th, 2025</para>
+      <itemizedlist>
+        <listitem>
+          <para>[seal331] - minicom: 2.9 -&gt; 2.10;
+          heirloom-ng: 59f7cc -&gt; 250220. Fixes
+          <ulink url="&lfs-qol-issues;/52">#52</ulink> and
+          <ulink url="&lfs-qol-issues;/60">#60</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>March 6th, 2025</para>
       <itemizedlist>
         <listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -53,7 +53,7 @@
 <!ENTITY s4-3b1-pc7300-minor-version         "efe55b">
 <!ENTITY s4-3b1-pc7300-version               "efe55b8cc917e3e27bcae9786c5b5dec0469be45">
 <!ENTITY lrzsz-version                       "0.12.20">
-<!ENTITY minicom-version                     "2.9">
+<!ENTITY minicom-version                     "2.10">
 <!ENTITY gkermit-tarball-version             "gku201">
 <!ENTITY gkermit-version                     "2.01">
 <!ENTITY p20-emu-minor-version               "d75a83">

--- a/packages.ent
+++ b/packages.ent
@@ -31,8 +31,7 @@
 <!ENTITY i3-version                          "4.24">
 
 <!-- 5. SVR4-TOOLS -->
-<!ENTITY heirloom-ng-minor-version           "59f7cc">
-<!ENTITY heirloom-ng-version                 "59f7cc870f72adc4a2df8a64acc75ab425d8ff6b">
+<!ENTITY heirloom-ng-version                 "250220">
 <!ENTITY schilytools-version                 "2024-03-21">
 <!ENTITY heirloom-sh-version                 "050706">
 <!ENTITY heirloom-doctools-minor-version     "2e9b0c">

--- a/svr4-tools/heirloom-ng.xml
+++ b/svr4-tools/heirloom-ng.xml
@@ -127,7 +127,7 @@ make</userinput></screen>
           echo, ed, egrep, env, expand, expr, factor, false, fgrep, file, find, 
           fmt, fmtmsg, fold, getconf, getopt, grep, groups, hd, head, hostname, 
           id, install, join, kill, lc, lib.b, line, listusers, ln, logins, 
-          logname, ls, magic, /usr/5bin/mail, man, mesg, mkdir, mkfifo, mknod, 
+          logname, ls, /usr/5bin/mail, man, mesg, mkdir, mkfifo, mknod, 
           more, mt, mv, mvdir, nawk, newform, news, nice, nl, nohup, oawk, od, 
           page, paste, pathchk, pax, pg, pgrep, pick, pkill, pr, printenv, 
           printf, priocntl, ps, psrinfo, ptime, pwd, random, readlink, renice, 

--- a/svr4-tools/heirloom-ng.xml
+++ b/svr4-tools/heirloom-ng.xml
@@ -122,19 +122,19 @@ make</userinput></screen>
          <seg>
           STTY, apply, apropos, awk, banner, basename, bc, bdiff, bfs, cal, 
           calendar, calprog, cat, catman, chgrp, chmod, chown, chroot, cksum, 
-          cmp, col, comm, copy, cp, cpio, csplit, cut, date, dc, dd, deroff, 
+          cmp, comm, copy, cp, cpio, csplit, cut, date, dc, dd, deroff, 
           df, dfspace, diff, diff3, diff3prog, diffh, dircmp, dirname, du, 
           echo, ed, egrep, env, expand, expr, factor, false, fgrep, file, find, 
           fmt, fmtmsg, fold, getconf, getopt, grep, groups, hd, head, hostname, 
           id, install, join, kill, lc, lib.b, line, listusers, ln, logins, 
-          logname, ls, magic, mail, man, mesg, mkdir, mkfifo, mknod, more, mt, 
-          mv, mvdir, nawk, newform, news, nice, nl, nohup, oawk, od, page, 
-          paste, pathchk, pax, pg, pgrep, pick, pkill, pr, printenv, printf, 
-          priocntl, ps, psrinfo, ptime, pwd, random, readlink, renice, rev, rm, 
-          rmdir, sdiff, sed, seq, setpgrp, settime, shl, sleep, sort, spell, 
-          split, stty, su, sum, sync, tabs, tail, tape, tapecntl, tar, tcopy, 
-          tee, test, time, timeout, touch, tr, true, tty, ul, uname, unexpand, 
-          uniq, units, unittab, uptime, users, w, wall, watch, wc, what, 
+          logname, ls, magic, /usr/5bin/mail, man, mesg, mkdir, mkfifo, mknod, 
+          more, mt, mv, mvdir, nawk, newform, news, nice, nl, nohup, oawk, od, 
+          page, paste, pathchk, pax, pg, pgrep, pick, pkill, pr, printenv, 
+          printf, priocntl, ps, psrinfo, ptime, pwd, random, readlink, renice, 
+          rev, rm, rmdir, sdiff, sed, seq, setpgrp, settime, shl, sleep, sort, 
+          spell, split, stty, su, sum, sync, tabs, tail, tape, tapecntl, tar, 
+          tcopy, tee, test, time, timeout, touch, tr, true, tty, ul, uname, 
+          unexpand, uniq, units, unittab, uptime, users, w, wall, watch, wc, 
           whatis, who, whoami, whodo, write, xargs, and yes 
          </seg>
         <seg>

--- a/svr4-tools/heirloom-ng.xml
+++ b/svr4-tools/heirloom-ng.xml
@@ -4,14 +4,14 @@
   <!ENTITY % general-entities SYSTEM "../general.ent">
   %general-entities;
 
-  <!ENTITY heirloom-ng-download-http "https://github.com/Projeto-Pindorama/heirloom-ng/archive/&heirloom-ng-version;.zip">
+  <!ENTITY heirloom-ng-download-http "https://github.com/Projeto-Pindorama/heirloom-ng/archive/&heirloom-ng-version;/heirloom-ng-&heirloom-ng-version;.tar.gz">
 ]>
 
-<sect1 id="heirloom-ng" xreflabel="heirloom-ng-&heirloom-ng-minor-version;">
+<sect1 id="heirloom-ng" xreflabel="heirloom-ng-&heirloom-ng-version;">
   <?dbhtml filename="heirloom-ng.html"?>
 
 
-  <title>heirloom-ng-&heirloom-ng-minor-version;</title>
+  <title>heirloom-ng-&heirloom-ng-version;</title>
 
   <indexterm zone="heirloom-ng">
     <primary sortas="a-heirloom-ng">heirloom-ng</primary>
@@ -41,37 +41,13 @@
       <listitem>
         <para>
           Required patch:
-          <ulink url="&patch-root;/svr4-tools/heirloom-ng/heirloom-ng-&heirloom-ng-minor-version;-no-static.patch"/>
+          <ulink url="&patch-root;/svr4-tools/heirloom-ng/heirloom-ng-&heirloom-ng-version;-no-static.patch"/>
         </para>
       </listitem>
       <listitem>
         <para>
           Required patch:
-          <ulink url="&patch-root;/svr4-tools/heirloom-ng/heirloom-ng-&heirloom-ng-minor-version;-fix-libcommon-build.patch"/>
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          Required patch:
-          <ulink url="&patch-root;/svr4-tools/heirloom-ng/heirloom-ng-&heirloom-ng-minor-version;-fix-chroot-build.patch"/>
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          Required patch:
-          <ulink url="&patch-root;/svr4-tools/heirloom-ng/heirloom-ng-&heirloom-ng-minor-version;-fix-date-build.patch"/>
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          Required patch:
-          <ulink url="&patch-root;/svr4-tools/heirloom-ng/heirloom-ng-&heirloom-ng-minor-version;-fix-shl-build.patch"/>
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          Required patch:
-          <ulink url="&patch-root;/svr4-tools/heirloom-ng/heirloom-ng-&heirloom-ng-minor-version;-dont-link-nonexistent-files.patch"/>
+          <ulink url="&patch-root;/svr4-tools/heirloom-ng/heirloom-ng-59f7cc-dont-link-nonexistent-files.patch"/>
         </para>
       </listitem>
     </itemizedlist>
@@ -80,8 +56,6 @@
 
     <bridgehead renderas="sect4">Required</bridgehead>
     <para role="required">
-      &unzip;
-      (to unpack the distribution) and
       <ulink url="&blfs-svn;/postlfs/ed.html">ed</ulink>
     </para>
   </sect2>
@@ -93,36 +67,27 @@
       Apply a patch to avoid usage of static libraries:
     </para>
 
-<screen><userinput>patch -Np1 -i ../heirloom-ng-&heirloom-ng-minor-version;-no-static.patch</userinput></screen>
-
-    <para>
-      Now, apply patches to fix builds of various components:
-    </para>
-
-<screen><userinput>patch -Np1 -i ../heirloom-ng-&heirloom-ng-minor-version;-fix-libcommon-build.patch &amp;&amp;
-patch -Np1 -i ../heirloom-ng-&heirloom-ng-minor-version;-fix-chroot-build.patch &amp;&amp;
-patch -Np1 -i ../heirloom-ng-&heirloom-ng-minor-version;-fix-date-build.patch &amp;&amp;
-patch -Np1 -i ../heirloom-ng-&heirloom-ng-minor-version;-fix-shl-build.patch</userinput></screen>
+<screen><userinput>patch -Np1 -i ../heirloom-ng-&heirloom-ng-version;-no-static.patch</userinput></screen>
 
     <para>
       Finally, apply a patch to avoid a failure during installation:
     </para>
 
-<screen><userinput>patch -Np1 -i ../heirloom-ng-&heirloom-ng-minor-version;-dont-link-nonexistent-files.patch</userinput></screen>
+<screen><userinput>patch -Np1 -i ../heirloom-ng-59f7cc-dont-link-nonexistent-files.patch</userinput></screen>
 
     <para>
       Install <application>heirloom-ng</application> by running the following
       command:
     </para>
 
-<screen><userinput>make</userinput></screen>
+<screen><userinput>sed -i 's/\-ltinfo//g' build/mk.config &amp;&amp;
+make</userinput></screen>
 
     <para>
       Now, as the &root; user:
     </para>
 
 <screen role="root"><userinput>make install</userinput></screen>
-
   
     <para>
       As the &root; user, remove binaries also shipped by 
@@ -134,6 +99,17 @@ patch -Np1 -i ../heirloom-ng-&heirloom-ng-minor-version;-fix-shl-build.patch</us
 
   </sect2>
 
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    <para>
+      <command>sed -i 's/\-ltinfo//g' build/mk.config</command>: This command avoids
+      linking against an <application>Ncurses</application> library that wasn't
+      built in LFS.
+    </para>
+
+  </sect2>
+
   <sect2 role="content">
     <title>Contents</title>
 
@@ -142,23 +118,25 @@ patch -Np1 -i ../heirloom-ng-&heirloom-ng-minor-version;-fix-shl-build.patch</us
       <segtitle>Installed Libraries</segtitle>
       <segtitle>Installed Directories</segtitle>
 
-      <seglistitem>
-        <seg>
-          STTY, apropos, awk, banner, basename, bc, bdiff, bfs, cal, calendar, 
-          cat, catman, chgrp, chmod, chown, chroot, cksum, cmp, comm, copy, cp, 
-          csplit, cut, date, dc, dd, deroff, df, dfspace, diff, diff3, 
-          diffh, dircmp, dirname, du, echo, ed, egrep, env, expand, expr, 
-          false, fgrep, file, find, fmt, fmtmsg, fold, getconf, getopt, grep, 
-          hd, head, hostname, id, install, join, kill, lc, line, listusers, ln, 
-          logname, ls, /usr/5bin/mail, man, mesg, mkdir, mkfifo, mknod, more, mt, mv, 
-          nawk, newform, news, nice, nl, nohup, oawk, od, page, paste, pathchk, 
-          pg, pgrep, pkill, pr, printenv, printf, priocntl, ps, psrinfo, ptime, 
-          random, readlink, renice, rm, rmdir, sdiff, sed, seq, setpgrp, 
-          shl, sleep, sort, spell, split, stty, su, sum, sync, tabs, tail, 
-          tapecntl, tar, tcopy, tee, test, time, touch, tr, true, tsort, tty, 
-          uname, unexpand, uniq, units, uptime, users, w, watch, wc, who, 
-          whoami, whodo, xargs, and yes 
-        </seg>
+        <seglistitem>
+         <seg>
+          STTY, apply, apropos, awk, banner, basename, bc, bdiff, bfs, cal, 
+          calendar, calprog, cat, catman, chgrp, chmod, chown, chroot, cksum, 
+          cmp, col, comm, copy, cp, cpio, csplit, cut, date, dc, dd, deroff, 
+          df, dfspace, diff, diff3, diff3prog, diffh, dircmp, dirname, du, 
+          echo, ed, egrep, env, expand, expr, factor, false, fgrep, file, find, 
+          fmt, fmtmsg, fold, getconf, getopt, grep, groups, hd, head, hostname, 
+          id, install, join, kill, lc, lib.b, line, listusers, ln, logins, 
+          logname, ls, magic, mail, man, mesg, mkdir, mkfifo, mknod, more, mt, 
+          mv, mvdir, nawk, newform, news, nice, nl, nohup, oawk, od, page, 
+          paste, pathchk, pax, pg, pgrep, pick, pkill, pr, printenv, printf, 
+          priocntl, ps, psrinfo, ptime, pwd, random, readlink, renice, rev, rm, 
+          rmdir, sdiff, sed, seq, setpgrp, settime, shl, sleep, sort, spell, 
+          split, stty, su, sum, sync, tabs, tail, tape, tapecntl, tar, tcopy, 
+          tee, test, time, timeout, touch, tr, true, tty, ul, uname, unexpand, 
+          uniq, units, unittab, uptime, users, w, wall, watch, wc, what, 
+          whatis, who, whoami, whodo, write, xargs, and yes 
+         </seg>
         <seg>
           None
         </seg>
@@ -181,6 +159,18 @@ patch -Np1 -i ../heirloom-ng-&heirloom-ng-minor-version;-fix-shl-build.patch</us
           </para>
           <indexterm zone="heirloom-ng STTY">
             <primary sortas="b-STTY">STTY</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry id="apply">
+        <term><command>apply</command></term>
+        <listitem>
+          <para>
+            repeatedly applies a command to a group of arguments
+          </para>
+          <indexterm zone="heirloom-ng apply">
+            <primary sortas="b-apply">apply</primary>
           </indexterm>
         </listitem>
       </varlistentry>
@@ -1305,6 +1295,18 @@ patch -Np1 -i ../heirloom-ng-&heirloom-ng-minor-version;-fix-shl-build.patch</us
         </listitem>
       </varlistentry>
 
+      <varlistentry id="pick">
+        <term><command>pick</command></term>
+        <listitem>
+          <para>
+            selects arguments
+          </para>
+          <indexterm zone="heirloom-ng pick">
+            <primary sortas="b-pick">pick</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+
       <varlistentry id="pkill">
         <term><command>pkill</command></term>
         <listitem>
@@ -1445,6 +1447,18 @@ patch -Np1 -i ../heirloom-ng-&heirloom-ng-minor-version;-fix-shl-build.patch</us
           </para>
           <indexterm zone="heirloom-ng renice">
             <primary sortas="b-renice">renice</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry id="rev">
+        <term><command>rev</command></term>
+        <listitem>
+          <para>
+            reverses lines of a file
+          </para>
+          <indexterm zone="heirloom-ng rev">
+            <primary sortas="b-rev">rev</primary>
           </indexterm>
         </listitem>
       </varlistentry>
@@ -1749,6 +1763,18 @@ patch -Np1 -i ../heirloom-ng-&heirloom-ng-minor-version;-fix-shl-build.patch</us
         </listitem>
       </varlistentry>
 
+      <varlistentry id="timeout">
+        <term><command>timeout</command></term>
+        <listitem>
+          <para>
+            executes a command with a time limit
+          </para>
+          <indexterm zone="heirloom-ng timeout">
+            <primary sortas="b-timeout">timeout</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+
       <varlistentry id="touch">
         <term><command>touch</command></term>
         <listitem>
@@ -1905,6 +1931,18 @@ patch -Np1 -i ../heirloom-ng-&heirloom-ng-minor-version;-fix-shl-build.patch</us
         </listitem>
       </varlistentry>
 
+      <varlistentry id="wall">
+        <term><command>wall</command></term>
+        <listitem>
+          <para>
+            writes to all users
+          </para>
+          <indexterm zone="heirloom-ng wall">
+            <primary sortas="b-wall">wall</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+
       <varlistentry id="watch">
         <term><command>watch</command></term>
         <listitem>
@@ -1973,6 +2011,18 @@ patch -Np1 -i ../heirloom-ng-&heirloom-ng-minor-version;-fix-shl-build.patch</us
           </para>
           <indexterm zone="heirloom-ng whodo">
             <primary sortas="b-whodo">whodo</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry id="write">
+        <term><command>write</command></term>
+        <listitem>
+          <para>
+            writes to another user
+          </para>
+          <indexterm zone="heirloom-ng write">
+            <primary sortas="b-write">write</primary>
           </indexterm>
         </listitem>
       </varlistentry>

--- a/svr4-tools/heirloom-ng.xml
+++ b/svr4-tools/heirloom-ng.xml
@@ -126,7 +126,7 @@ make</userinput></screen>
           df, dfspace, diff, diff3, diff3prog, diffh, dircmp, dirname, du, 
           echo, ed, egrep, env, expand, expr, factor, false, fgrep, file, find, 
           fmt, fmtmsg, fold, getconf, getopt, grep, groups, hd, head, hostname, 
-          id, install, join, kill, lc, lib.b, line, listusers, ln, logins, 
+          id, install, join, kill, lc, line, listusers, ln, logins, 
           logname, ls, /usr/5bin/mail, man, mesg, mkdir, mkfifo, mknod, 
           more, mt, mv, mvdir, nawk, newform, news, nice, nl, nohup, oawk, od, 
           page, paste, pathchk, pax, pg, pgrep, pick, pkill, pr, printenv, 
@@ -134,7 +134,7 @@ make</userinput></screen>
           rev, rm, rmdir, sdiff, sed, seq, setpgrp, settime, shl, sleep, sort, 
           spell, split, stty, su, sum, sync, tabs, tail, tape, tapecntl, tar, 
           tcopy, tee, test, time, timeout, touch, tr, true, tty, ul, uname, 
-          unexpand, uniq, units, unittab, uptime, users, w, wall, watch, wc, 
+          unexpand, uniq, units, uptime, users, w, wall, watch, wc, 
           whatis, who, whoami, whodo, write, xargs, and yes 
          </seg>
         <seg>

--- a/svr4-tools/heirloom-sh.xml
+++ b/svr4-tools/heirloom-sh.xml
@@ -96,7 +96,7 @@
 
       <para>
         As the &root; user, update <filename>/etc/shells</filename> to include
-        the Bourne shell program names (as the root user):
+        the Bourne shell program names:
       </para>
 
 <screen role="root"><userinput>cat &gt;&gt; /etc/shells &lt;&lt; "EOF"


### PR DESCRIPTION
This PR does the following:

updates Minicom to 2.10
updates heirloom-ng to 250220
fixes all kinds of minor stuff in the CDE chapter (the biggest issue was ksh not being in /etc/shells)
doesn't specify the exact same thing in heirloom-sh two times
fixes a major bug in the doc stub generator leading to incorrect binary lists being generated in most cases

Closes #52 and #60.