### PR TITLE
More bugfixes

### DIFF
--- a/cde/cde-de.xml
+++ b/cde/cde-de.xml
@@ -172,19 +172,21 @@ systemctl enable dtlogin.service
 
       <seglistitem>
         <seg>
-          Xsession, dsdm, dtaction, dtappgather, dtappintegrate, dtbuilder, 
-          dtchooser, dtcm, dtcm_delete, dtcm_editor, dtcm_insert, dtcm_lookup, 
-          dtcreate, dtdbcache, dtdocbook2infolib, dtdocbook2man, dtdocbook2sdl, 
-          dterror.ds, dtexec, dtfile, dtfile_copy, dtfile_error, dtfplist, 
-          dthello, dthelp_ctag1, dthelp_htag1, dthelp_htag2, dthelpgen, 
-          dthelpprint, dthelpprint.sh, dthelptag, dthelpview, dticon, 
-          dtinfo, dtinfo_start, dtksh, dtlogin, dtlp, dtlpsetup, dtmail, 
-          dtopen, dtopen_image (link to dtopen), dtopen_pdf (link to dtopen), 
-          dtopen_video (link to dtopen), dtpad, dtpdm, dtpdmd, dtprintegrate, 
-          dtscreen, dtsearchpath, dtsession, dtsession_res, dtspcd, dtsrclean, 
-          dtsrdbrec, dtsrdelete, dtsrhan, dtsrindex, dtsrkdump, dtsrload, 
-          dtterm, dttypes, dtwm, huffcode, rpc.cmsd, rpc.ttdbserver, 
-          ttauth, ttcp, ttdbck, ttmv, ttrm, ttrmdir, ttsession, ttsnoop, tttar, 
+          Xsession, dsdm, dtaction, dtappgather, dtappintegrate, dtbuilder,
+          dtcalc, dtchooser, dtcm, dtcm_delete, dtcm_editor, dtcm_insert,
+          dtcm_lookup, dtcodegen, dtcreate, dtdbcache, dtdocbook2infolib,
+          dtdocbook2man, dtdocbook2sdl, dtdspmsg, dterror.ds, dtexec, dtfile,
+          dtfile_copy, dtfile_error, dtfplist, dtgreet, dthello, dthelp_ctag1,
+          dthelp_htag1, dthelp_htag2, dthelpgen, dthelpgen.dtsh, dthelpprint,
+          dthelpprint.sh, dthelptag, dthelpview, dticon, dtimsstart, dtinfo,
+          dtksh, dtlogin, dtlp, dtlpsetup, dtmail, dtmailpr, dtopen,
+          dtopen_image (link to dtopen), dtopen_pdf (link to dtopen),
+          dtopen_ps (link to dtopen), dtopen_video (link to dtopen), dtpad,
+          dtpdm, dtpdmd, dtprintegrate, dtprintinfo, dtscreen, dtsearchpath,
+          dtsession, dtsession_res, dtspcd, dtsrclean, dtsrcreate, dtsrdbrec,
+          dtsrdelete, dtsrhan, dtsrindex, dtsrkdump, dtsrload, dtstyle, dtterm,
+          dttypes, dtwm, huffcode, rpc.cmsd, rpc.ttdbserver, tt_type_comp,
+          ttauth, ttcp, ttdbck, ttmv, ttrm, ttrmdir, ttsession, ttsnoop, tttar,
           and tttrace
         </seg>
         <seg>

--- a/generate-doc-stub.py
+++ b/generate-doc-stub.py
@@ -118,7 +118,13 @@ for i in filelist:
 		tmp3 = tmp2.split(', ')
 		tmp = '          ' + tmp3[-2] + ', '
 		tmp2 = ', '.join(tmp3[:-2])
-print(tmp2, end='')
+# this is a HACK to avoid generating incorrect binary lists in corner cases
+# where we already got through the entire filelist array, already printed out tmp2,
+# but there's still one binary left in tmp
+if tmp.count(', ') == 1:
+	print(tmp, end='')
+else:
+	print(tmp2, end='')
 print('''
         </seg>
         <seg>''')
@@ -136,7 +142,13 @@ else:
 			tmp3 = tmp2.split(', ')
 			tmp = '          ' + tmp3[-2] + ', '
 			tmp2 = ', '.join(tmp3[:-2])
-	print(tmp2, end='')
+	# this is a HACK to avoid generating incorrect library lists in corner cases
+	# where we already got through the entire liblist array, already printed out
+	# tmp2, but there's still one library left in tmp
+	if tmp.count(', ') == 1:
+		print(tmp, end='')
+	else:
+		print(tmp2, end='')
 	print()
 print('''        </seg>
         <seg>

--- a/generate-doc-stub.py
+++ b/generate-doc-stub.py
@@ -118,13 +118,7 @@ for i in filelist:
 		tmp3 = tmp2.split(', ')
 		tmp = '          ' + tmp3[-2] + ', '
 		tmp2 = ', '.join(tmp3[:-2])
-# this is a HACK to avoid generating incorrect binary lists in corner cases
-# where we already got through the entire filelist array, already printed out tmp2,
-# but there's still one binary left in tmp
-if tmp.count(', ') == 1:
-	print(tmp, end='')
-else:
-	print(tmp2, end='')
+print(tmp2, end='')
 print('''
         </seg>
         <seg>''')
@@ -142,13 +136,7 @@ else:
 			tmp3 = tmp2.split(', ')
 			tmp = '          ' + tmp3[-2] + ', '
 			tmp2 = ', '.join(tmp3[:-2])
-	# this is a HACK to avoid generating incorrect library lists in corner cases
-	# where we already got through the entire liblist array, already printed out
-	# tmp2, but there's still one library left in tmp
-	if tmp.count(', ') == 1:
-		print(tmp, end='')
-	else:
-		print(tmp2, end='')
+	print(tmp2, end='')
 	print()
 print('''        </seg>
         <seg>

--- a/patches/svr4-tools/heirloom-ng/heirloom-ng-250220-no-static.patch
+++ b/patches/svr4-tools/heirloom-ng/heirloom-ng-250220-no-static.patch
@@ -1,0 +1,46 @@
+--- heirloom-ng-250220/build/mk.config	2025-02-21 06:00:47.000000000 +0300
++++ heirloom-ng-250220-patched/build/mk.config	2025-03-09 20:11:16.757997260 +0300
+@@ -120,8 +120,8 @@
+ # Uncomment the definition below and comment the current definition if you are
+ # on the GNU C Library, since it doesn't seems to like static linking.
+ #
+-#LIBPATH = -L/lib
+-LIBPATH = -L/usr/lib -L/usr/ccs/lib
++LIBPATH = -L/lib
++#LIBPATH = -L/usr/lib -L/usr/ccs/lib
+ 
+ #
+ # Curses library. Change to -lncurses if necessary. Caution: Some gcc
+@@ -159,8 +159,8 @@
+ # Uncomment the definition below and comment the current definition if you
+ # are on the GNU C Library, since it doesn't seems to like static binaries.
+ #
+-#LIBZ = -Wl,-Bdynamic -lz
+-LIBZ = -Wl,-Bstatic -lz
++LIBZ = -Wl,-Bdynamic -lz
++#LIBZ = -Wl,-Bstatic -lz
+ USE_ZLIB = 1
+ 
+ #
+@@ -170,8 +170,8 @@
+ # Uncomment the definition below and comment the current definition if you
+ # are on the GNU C Library, since it doesn't seems to like static binaries.
+ #
+-#LIBBZ2 = -Wl,-Bdynamic -lbz2
+-LIBBZ2 = -Wl,-Bstatic -lbz2
++LIBBZ2 = -Wl,-Bdynamic -lbz2
++#LIBBZ2 = -Wl,-Bstatic -lbz2
+ USE_BZLIB = 1
+ 
+ #
+@@ -188,8 +188,8 @@
+ # you are on the GNU C Library, since it doesn't seems to like static
+ # binaries.
+ #
+-#LDFLAGS = $(LIBPATH)
+-LDFLAGS = -static $(LIBPATH)
++LDFLAGS = $(LIBPATH)
++#LDFLAGS = -static $(LIBPATH)
+ 
+ #
+ # Flags for the C preprocessor.

--- a/svr4-tools/heirloom-doctools.xml
+++ b/svr4-tools/heirloom-doctools.xml
@@ -81,9 +81,9 @@ install</userinput></screen>
       <seglistitem>
         <seg>
           addbib, checkeq, checknr, col, dhtml, dpost, eqn, grap, hunt, 
-          inv, lookbib, mkey, neqn, nroff, otf_info, pic, picpack, pm, ptx, 
-          roffbib, runinv, soelim, sortbib, ta, tbl, troff, vfontedpr, and
-          vgrind
+          indxbib, inv, lookbib, mkey, neqn, nroff, otf_info, pic, picpack, pm, 
+          ptx, refer, roffbib, runinv, soelim, sortbib, ta, tbl, troff, 
+          vfontedpr, and vgrind
         </seg>
         <seg>
           None

--- a/svr4-tools/heirloom-ex-vi.xml
+++ b/svr4-tools/heirloom-ex-vi.xml
@@ -130,7 +130,7 @@ make</userinput></screen>
       <seglistitem>
         <seg>
           edit (link to ex), ex, expreserve, exrecover, vedit (link to ex), 
-          view (link to ex), vi (link to ex), and wvi
+          vi (link to ex), view (link to ex), and wvi
         </seg>
         <seg>
           None

--- a/svr4-tools/pkgsuite.xml
+++ b/svr4-tools/pkgsuite.xml
@@ -98,21 +98,27 @@ make</userinput></screen>
       <seglistitem>
         <seg>
           ckdate, ckgid, ckint, ckitem, ckkeywd, ckpath, ckrange, ckstr, 
-          ckuid, ckyorn, cmdexec, dispgid (link to ckgid), errange 
-          (link to ckrange), errdate (link to ckdate), errint (link to ckint),
-          errkeywd (link to ckkeywd), errstr (link to ckstr), errtime (link to
-          cktime), erryorn (link to ckyorn), getdate (link to ckdate), getint 
-          (link to ckint), getkeywd (link to ckkeywd), getrange (link to 
-          ckrange), getstr (link to ckstr), getuid (link to ckuid), getyorn
-          (link to ckyorn), helpgid (link to ckgid), helpint (link to ckint), 
-          helppath (link to ckpath), helprange (link to ckrange), helptime
-          (link to cktime), helpuid (link to ckuid), i.CompCpio, i.awk,
-          i.build, i.sed, installf, pkgadd, pkgchk, pkginfo, pkginstall,
-          pkgmk, pkgname, pkgparam, pkgproto, pkgrm, pkgtrans, puttext, 
-          r.awk, r.build, r.sed, valdate (link to ckdate), valgid (link to
-          ckgid), valkeywd (link to ckkeywd), valpath (link to ckpath), valstr 
-          (link to ckstr), valtime (link to cktime), and valyorn (link to
-          ckyorn) 
+          cktime, ckuid, ckyorn, cmdexec, dispgid (link to ckgid), dispuid
+          (link to ckuid), errange (link to ckrange), errdate (link to 
+          ckdate), errgid (link to ckgid), errint (link to ckint), errkeywd 
+          (link to ckkeywd), errpath (link to ckpath), errstr (link to ckstr), 
+          errtime (link to cktime), erruid (link to ckuid), erryorn (link to 
+          ckyorn), getdate (link to ckdate), getgid (link to ckgid), getint 
+          (link to ckint), getkeywd (link to ckkeywd), getpath (link to 
+          ckpath), getrange (link to ckrange), getstr (link to ckstr), gettime 
+          (link to cktime), getuid (link to ckuid), getyorn (link to ckyorn), 
+          helpdate (link to ckdate), helpgid (link to ckgid), helpint (link 
+          to ckint), helpkeywd (link to ckkeywd), helppath (link to ckpath), 
+          helprange (link to ckrange), helpstr (link to ckstr), helptime 
+          (link to cktime), helpuid (link to ckuid), helpyorn (link to 
+          ckyorn), i.CompCpio, i.awk, i.build, i.sed, installf, pkgadd,
+          pkgask (link to pkgadd), pkgchk, pkginfo, pkginstall, pkgmk, 
+          pkgname, pkgparam, pkgproto, pkgremove, pkgrm, pkgtrans, puttext, 
+          r.awk, r.build, r.sed, removef (link to installf), valdate (link to 
+          ckdate), valgid (link to ckgid), valint (link to ckint), valkeywd 
+          (link to ckkeywd), valpath (link to ckpath), valrange (link to 
+          ckrange), valstr (link to ckstr), valtime (link to cktime), valuid 
+          (link to ckuid), and valyorn (link to ckyorn)
         </seg>
         <seg>
           None


### PR DESCRIPTION
This PR does the following:

~~fixes another corner case in docstubgen uncovered during fixing CDE's binaries list which (I think) got introduced by the 80 column line fix~~ reverted to not clutter this PR up so much and for easier integration of new features and bugfixes from different WIP branch
fixes binary lists in multiple packages which were affected by the 80 column bug
adds a patch I forgot to commit which is required for heirloom-ng build