### PR TITLE
Fix a typo in Flatpak

### DIFF
--- a/binary/flatpak.xml
+++ b/binary/flatpak.xml
@@ -38,7 +38,7 @@
       </listitem>
     </itemizedlist>
 
-    <bridgehead renderas="sect3">OSTree Dependencies</bridgehead>
+    <bridgehead renderas="sect3">Flatpak Dependencies</bridgehead>
 
     <bridgehead renderas="sect4">Required</bridgehead>
     <para role="required">


### PR DESCRIPTION
List the dependencies for Flatpak, not OSTree