### PR TITLE
Add Lotus 123 (and a General Utilities chapter)

### DIFF
--- a/general-utils/general-utils.xml
+++ b/general-utils/general-utils.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+   "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+  <!ENTITY % general-entities SYSTEM "../general.ent">
+  %general-entities;
+]>
+
+<chapter id="general-utils">
+  <?dbhtml filename="general-utils.html" dir="general-utils"?>
+
+  <title>General Utilities</title>
+
+  <para>
+    This section is dedicated to various utilities useful for all kinds of
+    purposes.
+  </para>
+
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="lotus123.xml"/>
+
+</chapter>

--- a/general-utils/lotus123.xml
+++ b/general-utils/lotus123.xml
@@ -5,15 +5,6 @@
   %general-entities;
 
   <!ENTITY lotus123-download-http "https://github.com/taviso/123elf/archive/v&lotus123-version;/123elf-v&lotus123-version;.tar.gz">
-  <!-- DO NOT KEEP THIS UP TO DATE. Do not sync this with LFS, do not sync
-  this up with the latest version, ONLY sync this with upstream. We're
-  dealing with decades-old proprietary software here, not even meant to work
-  on Linux, whose port to Linux was only possible because of dlopen() not being
-  a common thing on 90s UNIX and the software needing plugin support. I do NOT
-  want to spend an entire day debugging this and single stepping stuff with gdb
-  because there was a regression in binutils regarding i386 COFF, a format
-  which barely anyone uses these days. This is a known-working
-  upstream-recommended version, so keep this at that. -->
   <!ENTITY lotus123-binutils-download-http "https://ftp.gnu.org/gnu/binutils/binutils-&lotus123-binutils-version;.tar.gz">
 ]>
 
@@ -90,6 +81,24 @@
 
 <screen><userinput>for i in 1 2 3 4 5; do wget \
 https://archive.org/download/123-unix/123UNIX$i.IMG; done</userinput></screen>
+
+    <warning><para>
+      <emphasis>DO NOT</emphasis> use any other binutils versions than the one
+      used in the book to compile this package. This is decades-old proprietary
+      software, not ever meant to work on Linux, whose port to Linux was only
+      possible because of technical issues with UNIXen of the day making it
+      impossible to support third-party plugins without shipping object code.
+      The format used for said object code is i386 COFF, which barely anyone
+      uses these days. This version of binutils is the exact same one used
+      in the upstream packaging scripts, and is known to have no critical
+      issues regarding this format. If you use a different binutils version,
+      you may very run into regressions which break the app in various ways.
+      And if you do run into issues with this version of binutils, then you'll
+      actually be able to report this upstream. If your binutils fails to build,
+      <emphasis>DO NOT</emphasis> use a newer version. Report this to the
+      LFS-QOL editors in order for this to be fixed for everyone without
+      possibly opening up the door to critical regressions.
+    </para></warning>
 
     <para>
       Now, compile the required parts of binutils with COFF support enabled:

--- a/general-utils/lotus123.xml
+++ b/general-utils/lotus123.xml
@@ -5,6 +5,15 @@
   %general-entities;
 
   <!ENTITY lotus123-download-http "https://github.com/taviso/123elf/archive/v&lotus123-version;/123elf-v&lotus123-version;.tar.gz">
+  <!-- DO NOT KEEP THIS UP TO DATE. Do not sync this with LFS, do not sync
+  this up with the latest version, ONLY sync this with upstream. We're
+  dealing with decades-old proprietary software here, not even meant to work
+  on Linux, whose port to Linux was only possible because of dlopen() not being
+  a common thing on 90s UNIX and the software needing plugin support. I do NOT
+  want to spend an entire day debugging this and single stepping stuff with gdb
+  because there was a regression in binutils regarding i386 COFF, a format
+  which barely anyone uses these days. This is a known-working
+  upstream-recommended version, so keep this at that. -->
   <!ENTITY lotus123-binutils-download-http "https://ftp.gnu.org/gnu/binutils/binutils-&lotus123-binutils-version;.tar.gz">
 ]>
 
@@ -26,7 +35,8 @@
       a base.
     </para>
 
-    <note><para>This package requires a multilib system.</para></note>
+    <note><para>This package requires either a 32-bit system or a 64-bit
+    system with 32-bit application support.</para></note>
 
     <bridgehead renderas="sect3">Package Information</bridgehead>
     <itemizedlist spacing="compact">
@@ -73,8 +83,9 @@
 <screen><userinput>patch -Np1 -i ../lotus123-&lotus123-version;-final-updates.patch</userinput></screen>
 
     <para>
-      Then, download the required disk images by executing the following
-      commands:
+      Then, in order to download the required disk images using
+      <ulink url="&blfs-svn;/basicnet/wget.html">Wget</ulink>,
+      execute the following commands:
     </para>
 
 <screen><userinput>for i in 1 2 3 4 5; do wget \
@@ -125,7 +136,6 @@ make</userinput></screen>
       <parameter>sed -i 's/\-ltinfo//g' ...</parameter>: This command avoids 
       linking against an <application>Ncurses</application> library that wasn't
       built in LFS.
-
     </para>
 
   </sect2>

--- a/general-utils/lotus123.xml
+++ b/general-utils/lotus123.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sect1 PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+   "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+  <!ENTITY % general-entities SYSTEM "../general.ent">
+  %general-entities;
+
+  <!ENTITY lotus123-download-http "https://github.com/taviso/123elf/archive/v&lotus123-version;/123elf-v&lotus123-version;.tar.gz">
+  <!ENTITY lotus123-binutils-download-http "https://ftp.gnu.org/gnu/binutils/binutils-&lotus123-binutils-version;.tar.gz">
+]>
+
+<sect1 id="lotus123" xreflabel="lotus123-&lotus123-version;">
+  <?dbhtml filename="lotus123.html"?>
+
+  <title>Lotus 1-2-3 R3 for Linux &lotus123-version;</title>
+
+  <indexterm zone="lotus123">
+    <primary sortas="a-lotus123">lotus123</primary>
+  </indexterm>
+
+  <sect2 role="package">
+    <title>Introduction to Lotus 1-2-3</title>
+
+    <para>
+      Lotus 1-2-3 was a popular spreadsheet back in the 1980s and 1990s. This
+      package is an unofficial port of it to Linux using the UNIX version as
+      a base.
+    </para>
+
+    <note><para>This package requires a multilib system.</para></note>
+
+    <bridgehead renderas="sect3">Package Information</bridgehead>
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          Download (HTTP): <ulink url="&lotus123-download-http;"/>
+        </para>
+      </listitem>
+    </itemizedlist>
+
+    <bridgehead renderas="sect3">Additional Downloads</bridgehead>
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          Required patch:
+          <ulink url="&patch-root;/general-utils/lotus123/lotus123-&lotus123-version;-final-updates.patch"/>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Required binutils version:
+          <ulink url="&lotus123-binutils-download-http;"/>
+        </para>
+      </listitem>
+    </itemizedlist>
+
+    <bridgehead renderas="sect3">Lotus 1-2-3 Dependencies</bridgehead>
+
+    <bridgehead renderas="sect4">Required</bridgehead>
+    <para role="required">
+      <ulink url="&blfs-svn;/general/cpio.html">cpio</ulink>
+    </para>
+
+  </sect2>
+
+  <sect2 role="installation">
+    <title>Installation of lotus123</title>
+
+    <para>
+      First, apply a patch to bring the source up to the latest upstream
+      commit:
+    </para>
+
+<screen><userinput>patch -Np1 -i ../lotus123-&lotus123-version;-final-updates.patch</userinput></screen>
+
+    <para>
+      Then, download the required disk images by executing the following
+      commands:
+    </para>
+
+<screen><userinput>for i in 1 2 3 4 5; do wget \
+https://archive.org/download/123-unix/123UNIX$i.IMG; done</userinput></screen>
+
+    <para>
+      Now, compile the required parts of binutils with COFF support enabled:
+    </para>
+
+<!-- No, I have no idea why i386-pc-elf32 somehow enables COFF -->
+<!-- Yes, it does work -->
+<screen><userinput>tar -xvf ../binutils-&lotus123-binutils-version;.tar.gz &amp;&amp;
+cd binutils-&lotus123-binutils-version; &amp;&amp;
+./configure --enable-targets=i386-pc-elf32 \
+            --disable-gas                  \
+            --disable-libctf               \
+            --disable-plugins              \
+            --disable-gprof                \
+            --enable-compressed-debug-sections=none &amp;&amp;
+make all-ld MAKEINFO=true &amp;&amp;
+cd .. &amp;&amp;
+cp -v binutils-&lotus123-binutils-version;/binutils/obj{copy,dump} . &amp;&amp;
+cp -v binutils-&lotus123-binutils-version;/ld/ld-new ld</userinput></screen>
+
+    <para>
+      In order to compile <application>Lotus 1-2-3</application>, execute the
+      following commands:
+    </para>
+
+<screen><userinput>./extract.sh &amp;&amp;
+sed -i 's/\-ltinfo//g' Makefile &amp;&amp;
+sed -i 's/\-ltinfo//g' keymap/Makefile &amp;&amp;
+sed -i 's/\-ltinfo//g' ttydraw/Makefile &amp;&amp;
+make</userinput></screen>
+
+    <para>
+      Now, as the &root; user:
+    </para>
+
+<screen role="root"><userinput>make prefix=/usr install</userinput></screen>
+
+  </sect2>
+  
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    <para>
+      <parameter>sed -i 's/\-ltinfo//g' ...</parameter>: This command avoids 
+      linking against an <application>Ncurses</application> library that wasn't
+      built in LFS.
+
+    </para>
+
+  </sect2>
+
+  <sect2 role="content">
+    <title>Contents</title>
+
+    <segmentedlist>
+      <segtitle>Installed Programs</segtitle>
+      <segtitle>Installed Libraries</segtitle>
+      <segtitle>Installed Directories</segtitle>
+
+      <seglistitem>
+        <seg>
+          123
+        </seg>
+        <seg>
+          None
+        </seg>
+        <seg>
+          /usr/share/lotus
+        </seg>
+      </seglistitem>
+    </segmentedlist>
+
+    <variablelist>
+      <bridgehead renderas="sect3">Short Descriptions</bridgehead>
+      <?dbfo list-presentation="list"?>
+      <?dbhtml list-presentation="table"?>
+
+      <varlistentry id="prog123">
+        <term><command>123</command></term>
+        <listitem>
+         <para>
+           is the spreadsheet app
+         </para>
+          <indexterm zone="lotus123 prog123">
+            <primary sortas="b-123">123</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+
+    </variablelist>
+
+  </sect2>
+
+</sect1>

--- a/index.xml
+++ b/index.xml
@@ -24,6 +24,7 @@ $Date$
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="gen-game/gen-game.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="dev-tools/dev-tools.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="cde/cde.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="general-utils/general-utils.xml"/>
 
   <!-- Appendices -->
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="appendices/creat-comm.xml"/>

--- a/introduction/changelog.xml
+++ b/introduction/changelog.xml
@@ -40,6 +40,16 @@
     -->
 
     <listitem>
+      <para>March 13th, 2025</para>
+      <itemizedlist>
+        <listitem>
+          <para>[seal331] - general-utilities/*: Added. PR
+          <ulink url="&lfs-qol-pull;/75">(#75)</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>March 9th, 2025</para>
       <itemizedlist>
         <listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -101,3 +101,16 @@
 <!ENTITY ksh-version                         "1.0.10">
 <!ENTITY ncompress-version                   "5.0">
 <!ENTITY cde-de-version                      "2.5.2">
+
+<!-- 11. GENERAL-UTILS -->
+<!ENTITY lotus123-version                    "1.0.0rc4">
+<!-- DO NOT KEEP THIS UP TO DATE. Do not sync this with LFS, do not sync
+this up with the latest version, ONLY sync this with upstream. We're
+dealing with decades-old proprietary software here, not even meant to work
+on Linux, whose port to Linux was only possible because of dlopen() not being
+a common thing on 90s UNIX and the software needing plugin support. I do NOT
+want to spend an entire day debugging this and single stepping stuff with gdb
+because there was a regression in binutils regarding i386 COFF, a format which
+barely anyone uses these days. This is a known-working upstream-recommended
+version, so keep this at that. -->
+<!ENTITY lotus123-binutils-version           "2.38">

--- a/patches/general-utils/lotus123/lotus123-1.0.0rc4-final-updates.patch
+++ b/patches/general-utils/lotus123/lotus123-1.0.0rc4-final-updates.patch
@@ -1,0 +1,228 @@
+diff -Naur 123elf-1.0.0rc4/atfuncs/atfuncs.c 123elf-git/atfuncs/atfuncs.c
+--- 123elf-1.0.0rc4/atfuncs/atfuncs.c	2023-03-28 07:35:44.000000000 +0300
++++ 123elf-git/atfuncs/atfuncs.c	2025-03-13 17:11:05.125010263 +0300
+@@ -12,7 +12,9 @@
+     // Setup any @functions here.
+     functions[AT_WEEKDAY] = (atfunc_t) at_weekday;
+     functions[AT_PRODUCT] = (atfunc_t) at_product;
++    functions[AT_SYSTEM] = (atfunc_t) at_system;
+ 
+     // You can pass 1 or more parameters to @PRODUCT().
+     fn_numargs[AT_PRODUCT] = AT_ARGS_VARIABLE | 1;
++    fn_numargs[AT_SYSTEM] = 1;
+ }
+diff -Naur 123elf-1.0.0rc4/atfuncs/atfuncs.h 123elf-git/atfuncs/atfuncs.h
+--- 123elf-1.0.0rc4/atfuncs/atfuncs.h	2023-03-28 07:35:44.000000000 +0300
++++ 123elf-git/atfuncs/atfuncs.h	2025-03-13 17:11:05.125776607 +0300
+@@ -16,17 +16,23 @@
+ 
+ extern int16_t check_three_numbers();
+ extern int16_t check_one_number();
++extern int16_t check_one_string();
+ extern int16_t get_integer();
+ extern int16_t push_integer(uint16_t val);
+ extern int16_t push_one();
+ extern int16_t push_zero();
++extern int16_t push_na();
++extern int16_t drop_one_push_err();
++extern int16_t drop_one_push_stack_string(char *str);
++extern char * peek_string(int16_t n);
+ extern void mod_real_d();
+ extern void int_real_d();
+ extern void drop_one();
+ extern void swap_TOS();
+ 
+-// @PRODUCT replaced the previously unimplemented @CALL
++// Replaced previously unimplemented functions
+ #define AT_CALL AT_PRODUCT
++#define AT_TERM2 AT_SYSTEM
+ 
+ enum {
+     AT_NA,
+@@ -162,7 +168,7 @@
+     AT_PMT2,
+     AT_PV2,
+     AT_FV2,
+-    AT_TERM2,
++    AT_SYSTEM,
+     AT_NUM_FUNCS,
+ };
+ 
+@@ -173,6 +179,7 @@
+ 
+ int16_t at_date();
+ int16_t at_weekday();
++int16_t at_system();
+ int16_t at_product(int16_t cnt);
+ 
+ void init_at_funcs();
+diff -Naur 123elf-1.0.0rc4/atfuncs/Makefile 123elf-git/atfuncs/Makefile
+--- 123elf-1.0.0rc4/atfuncs/Makefile	2023-03-28 07:35:44.000000000 +0300
++++ 123elf-git/atfuncs/Makefile	2025-03-13 17:11:05.123776607 +0300
+@@ -7,7 +7,7 @@
+ 
+ all: atfuncs.a
+ 
+-atfuncs.a: date.o weekday.o product.o atfuncs.o
++atfuncs.a: date.o weekday.o product.o atfuncs.o system.o
+ 	$(AR) r $@ $^
+ 
+ clean:
+diff -Naur 123elf-1.0.0rc4/atfuncs/system.c 123elf-git/atfuncs/system.c
+--- 123elf-1.0.0rc4/atfuncs/system.c	1970-01-01 03:00:00.000000000 +0300
++++ 123elf-git/atfuncs/system.c	2025-03-13 17:11:05.128776607 +0300
+@@ -0,0 +1,44 @@
++#include <stdint.h>
++#include <stdlib.h>
++#include <stdio.h>
++#include <stdbool.h>
++#include <stddef.h>
++
++#include "lottypes.h"
++#include "lotfuncs.h"
++#include "lotdefs.h"
++#include "atfuncs.h"
++
++int16_t at_system()
++{
++    FILE *cmd;
++    char buf[512] = {0};
++
++    if (!check_one_string()) {
++        return 0;
++    }
++
++    // @SYSTEM() is only permitted when autoexec is enabled.
++    if (get_allow_autoexec() == false) {
++        drop_one();
++        push_na();
++        return 1;
++    }
++
++    cmd = popen(peek_string(0), "r");
++
++    if (cmd == NULL) {
++        return drop_one_push_err();
++    }
++
++    // We can read at most 512 bytes of output.
++    fscanf(cmd, "%511[^\n]", buf);
++
++    // We return @ERR if the command returned failure.
++    if (pclose(cmd) != EXIT_SUCCESS) {
++        return drop_one_push_err();
++    }
++
++    // Return the output as a string.
++    return drop_one_push_stack_string(buf);
++}
+diff -Naur 123elf-1.0.0rc4/coffsyrup.c 123elf-git/coffsyrup.c
+--- 123elf-1.0.0rc4/coffsyrup.c	2023-03-28 07:35:44.000000000 +0300
++++ 123elf-git/coffsyrup.c	2025-03-13 17:11:05.130776606 +0300
+@@ -347,7 +347,7 @@
+             // with a jmp, and then add a new RELOC. This really only makes sense
+             // if this is a function, so it should begin with push ebp.
+             if (patch->opcode != OPCODE_PUSH_EBP) {
+-                errx(EXIT_FAILURE, "Text symbol is missing a function prologue.");
++                warnx("Text symbol is missing a function prologue.");
+             }
+ 
+             // Now patch it with a JMP, is this right??
+diff -Naur 123elf-1.0.0rc4/globalize.lst 123elf-git/globalize.lst
+--- 123elf-1.0.0rc4/globalize.lst	2023-03-28 07:35:44.000000000 +0300
++++ 123elf-git/globalize.lst	2025-03-13 17:11:05.133776606 +0300
+@@ -83,3 +83,6 @@
+ filename_length
+ mac_nobreak
+ mac_str
++drop_one_push_stack_string
++drop_one_push_err
++get_allow_autoexec
+diff -Naur 123elf-1.0.0rc4/lotdefs.h 123elf-git/lotdefs.h
+--- 123elf-1.0.0rc4/lotdefs.h	2023-03-28 07:35:44.000000000 +0300
++++ 123elf-git/lotdefs.h	2025-03-13 17:11:05.142776606 +0300
+@@ -248,4 +248,5 @@
+ extern int win_column_width(uint16_t, int16_t);
+ extern void tty_disp_info(struct DISPLAYINFO *dpyinfo);
+ extern void memdup(void *, uint32_t, uint32_t);
++extern int16_t get_allow_autoexec();
+ #endif
+diff -Naur 123elf-1.0.0rc4/patch.c 123elf-git/patch.c
+--- 123elf-1.0.0rc4/patch.c	2023-03-28 07:35:44.000000000 +0300
++++ 123elf-git/patch.c	2025-03-13 17:11:05.145776605 +0300
+@@ -82,7 +82,7 @@
+ uint32_t fmt_cpy(uint32_t *dst, uint32_t *src, uint16_t src_len)
+ {
+     static const uint32_t dst_max = 256;
+-    uint32_t *dptr, *dst_end = dst + dst_max / 4;
++    uint32_t *dptr, *dst_end = dst + dst_max;
+ 
+     for (dptr = dst; src_len >= 4 && dptr < dst_end; dptr++) {
+         *dptr = *src++;
+diff -Naur 123elf-1.0.0rc4/res/l123txt3.txt 123elf-git/res/l123txt3.txt
+--- 123elf-1.0.0rc4/res/l123txt3.txt	2023-03-28 07:35:44.000000000 +0300
++++ 123elf-git/res/l123txt3.txt	2025-03-13 17:11:05.148776605 +0300
+@@ -2767,7 +2767,7 @@
+ 130 "PMT2"
+ 131 "PV2"
+ 132 "FV2"
+-133 "TERM2"
++133 "SYSTEM"
+ 134 "?"
+ 
+ =group 21, 256 bytes
+diff -Naur 123elf-1.0.0rc4/test/runtests.sh 123elf-git/test/runtests.sh
+--- 123elf-1.0.0rc4/test/runtests.sh	2023-03-28 07:35:44.000000000 +0300
++++ 123elf-git/test/runtests.sh	2025-03-13 17:11:05.153872408 +0300
+@@ -704,6 +704,10 @@
+     verify_result_contents '@UPPER("hello")' "HELLO"
+     verify_result_contents '@WEEKDAY(@DATE(2001,12,25))' "3"
+     verify_result_contents '@PRODUCT(1,2,3)' "6"
++    verify_result_contents '@ISERR(@SYSTEM("false"))' "1"
++    verify_result_contents '@ISERR(@SYSTEM("true"))' "0"
++    verify_result_contents '@SYSTEM("printf XyZzY")' "XyZzY"
++    verify_result_contents '@VALUE(@SYSTEM("echo 32+6 | bc"))' "38"
+ }
+ 
+ function check_crash_bugs()
+@@ -712,6 +716,28 @@
+         runmacro "~$(quit)" "testcases/bug103.wk3"
+         endtest
+     }
++    starttest "Large Range Combine" && {
++        local protect=$(mktemp -u)
++        local presave=$(mktemp -u)
++        local pstsave=$(mktemp -u)
++        local savewks=$(mktemp -u XXXXXXXXXX.wk3)
++        macro=$(sendkeys '/dfA1..BM1~~~64~')
++        macro+=$(goto A2)
++        macro+=$(writerange "${protect}" '@STRING(@CELL("protect",BM1),0)')
++        macro+=$(sendkeys '/ruA1..BM1~')
++        macro+=$(writerange "${presave}" '@STRING(@CELL("protect",BM1),0)')
++        macro+=$(saveas "${savewks}")
++        macro+=$(retrieve "${savewks}")
++        macro+=$(writerange "${pstsave}" '@STRING(@CELL("protect",BM1),0)')
++        macro+=$(quit)
++        runmacro "${macro}"
++
++        verifycontents "${protect}" "1"
++        verifycontents "${presave}" "0"
++        verifycontents "${pstsave}" "0"
++        endtest "${savewks}" "${protect}" "${presave}" "${pstsave}"
++    }
++
+ }
+ 
+ function run_all_tests()
+diff -Naur 123elf-1.0.0rc4/wrappers.c 123elf-git/wrappers.c
+--- 123elf-1.0.0rc4/wrappers.c	2023-03-28 07:35:44.000000000 +0300
++++ 123elf-git/wrappers.c	2025-03-13 17:11:05.169776603 +0300
+@@ -163,7 +163,7 @@
+             // I think these are the only flags you can change.
+             if (unixflags & 4)
+                 linuxflags |= O_NONBLOCK;
+-            if (linuxflags & 8)
++            if (unixflags & 8)
+                 linuxflags |= O_APPEND;
+ 
+             if (fcntl(fd, cmd, &linuxflags) == 0) {


### PR DESCRIPTION
This PR adds a General Utilities chapter and Lotus 1-2-3, an old spreadsheet tool that has been unofficially ported to Linux as a result of some technical issues with UNIX in the 90s making it impossible to support third-party loadable plugins without shipping object code.