### PR TITLE
Add neofetch page to General Utilities chapter

### DIFF
--- a/general-utils/general-utils.xml
+++ b/general-utils/general-utils.xml
@@ -16,5 +16,6 @@
   </para>
 
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="lotus123.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="neofetch.xml"/>
 
 </chapter>

--- a/general-utils/neofetch.xml
+++ b/general-utils/neofetch.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sect1 PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+   "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+  <!ENTITY % general-entities SYSTEM "../general.ent">
+  %general-entities;
+
+  <!ENTITY neofetch-download-http "https://github.com/dylanaraps/neofetch/archive/&neofetch-version;/neofetch-&neofetch-version;.tar.gz">
+]>
+
+<sect1 id="neofetch" xreflabel="neofetch-&neofetch-version;">
+  <?dbhtml filename="neofetch.html"?>
+
+  <title>neofetch-&neofetch-version;</title>
+
+  <indexterm zone="neofetch">
+    <primary sortas="a-neofetch">neofetch</primary>
+  </indexterm>
+
+  <sect2 role="package">
+    <title>Introduction to neofetch</title>
+
+    <para>
+      The <application>neofetch</application> package contains the 
+      <application>neofetch</application> script which outputs information 
+      about the system alongside ASCII art of the system's distro.
+    </para>
+
+    <note>
+      <para>
+        Neofetch has been archived since Apr 26, 2024. It is advisable to use a 
+        more maintained fork or alternative such as <application>
+        hyfetch</application> or <application>fastfetch</application>.
+      </para>
+    </note>
+
+    <bridgehead renderas="sect3">Package Information</bridgehead>
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          Download (HTTP): <ulink url="&neofetch-download-http;"/>
+        </para>
+      </listitem>
+    </itemizedlist>
+  </sect2>
+
+  <sect2 role="installation">
+    <title>Installation of neofetch</title>
+
+    <para>
+      <application>neofetch</application> does not need to be compiled and can 
+      be directly installed by running the following command as the &root; 
+      user:
+    </para>
+
+<screen role="root"><userinput>make install</userinput></screen>
+
+  </sect2>
+
+  <sect2 role="content">
+    <title>Contents</title>
+
+    <segmentedlist>
+      <segtitle>Installed Programs</segtitle>
+      <segtitle>Installed Libraries</segtitle>
+      <segtitle>Installed Directories</segtitle>
+
+      <seglistitem>
+        <seg>
+          neofetch
+        </seg>
+        <seg>
+          None
+        </seg>
+        <seg>
+          None
+        </seg>
+      </seglistitem>
+    </segmentedlist>
+
+    <variablelist>
+      <bridgehead renderas="sect3">Short Descriptions</bridgehead>
+      <?dbfo list-presentation="list"?>
+      <?dbhtml list-presentation="table"?>
+
+      <varlistentry id="neofetch-bin">
+        <term><command>neofetch</command></term>
+        <listitem>
+          <para>
+            Outputs information about the system and displays ASCII art of the 
+            system's distro
+          </para>
+          <indexterm zone="neofetch neofetch-bin">
+            <primary sortas="b-neofetch-bin">neofetch</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+
+    </variablelist>
+  </sect2>
+</sect1>

--- a/introduction/changelog.xml
+++ b/introduction/changelog.xml
@@ -40,6 +40,16 @@
     -->
 
     <listitem>
+      <para>March 16th, 2025</para>
+      <itemizedlist>
+        <listitem>
+          <para>[MymeType] - neofetch: Added. PR
+          <ulink url="&lfs-qol-pull;/80">(#80)</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>March 13th, 2025</para>
       <itemizedlist>
         <listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -114,3 +114,4 @@ because there was a regression in binutils regarding i386 COFF, a format which
 barely anyone uses these days. This is a known-working upstream-recommended
 version, so keep this at that. -->
 <!ENTITY lotus123-binutils-version           "2.38">
+<!ENTITY neofetch-version                    "7.1.0">


### PR DESCRIPTION
Now that there is a general utilities chapter in LFS-QOL, I figured it would now be fine to add neofetch (#66) in this chapter, as mentioned in the previous pull request. As also previously mentioned, I plan to add additional neofetch alternatives in the future, such as hyfetch and fastfetch.