### PR TITLE
Bugfixes (once again)

### DIFF
--- a/contributor-tools/docstubgen/docstubgen
+++ b/contributor-tools/docstubgen/docstubgen
@@ -34,6 +34,8 @@ def checklib(i, f):
 		f)) or ".so" in os.path.basename(os.path.join(i, f))))
 
 def callcheckfile(path):
+	if not checkbinflag:
+		return 0
 	if not idontcareaboutsecurity:
 		dangerouschars = dict.fromkeys(map(ord, "&'\"\\|><"), None)
 		path2 = path.translate(dangerouschars)

--- a/svr4/svr4-tools/heirloom-ng.xml
+++ b/svr4/svr4-tools/heirloom-ng.xml
@@ -70,7 +70,7 @@
 <screen><userinput>patch -Np1 -i ../heirloom-ng-&heirloom-ng-version;-no-static.patch</userinput></screen>
 
     <para>
-      Finally, apply a patch to avoid a failure during installation:
+      Then, apply a patch to avoid a failure during installation:
     </para>
 
 <screen><userinput>patch -Np1 -i ../heirloom-ng-59f7cc-dont-link-nonexistent-files.patch</userinput></screen>


### PR DESCRIPTION
This PR does the following:

- fixes a runtime error in docstubgen which appears when DOCSTUBGEN_BINARY_DETECT is unset (once again, I really shouldn't work on docstubgen at like 11PM)
- fixes a minor documentation issue in heirloom-ng caused by removing the no-longer-needed-after-update "fix build of component x" patches