### PR TITLE
docstubgen: conform to new library notation

### DIFF
--- a/contributor-tools/Makefile
+++ b/contributor-tools/Makefile
@@ -24,7 +24,7 @@ prep:
 	mkdir -p $(OBJDIR)/docstubgen
 
 build-docstubgen-manpage: $(OBJDIR)/docstubgen/docstubgen.1
-$(OBJDIR)/docstubgen/docstubgen.1: docstubgen/docstubgen.1.xml
+$(OBJDIR)/docstubgen/docstubgen.1: docstubgen/docstubgen.1.xml FRC
 	xsltproc --output $(OBJDIR)/docstubgen/ $(XSLSTYLESHEET) docstubgen/docstubgen.1.xml
 
 build-docstubgen: $(OBJDIR)/docstubgen/docstubgen $(OBJDIR)/docstubgen/docstubgen-checkfile

--- a/contributor-tools/Makefile
+++ b/contributor-tools/Makefile
@@ -10,7 +10,7 @@ LIBEXECDIR ?= libexec
 SHAREDIR ?= share
 OBJDIR ?= obj
 
-all: src man
+all: prep src man
 src: prep build-docstubgen
 man: prep build-docstubgen-manpage
 install: src install-docstubgen install-docstubgen-compat-symlink

--- a/contributor-tools/Makefile
+++ b/contributor-tools/Makefile
@@ -27,7 +27,7 @@ $(OBJDIR)/docstubgen/docstubgen.1: docstubgen/docstubgen.1.xml
 	cp docstubgen/docstubgen-checkfile $(OBJDIR)/docstubgen/
 
 install-docstubgen:
-	sed -e 's/\#prefix\#/"\$(PREFIX)"/g' -e 's/\#libexecdir\#/"$(LIBEXECDIR)"/g' -i $(OBJDIR)/docstubgen/docstubgen
+	sed -e 's=#prefix#="$(PREFIX)"=g' -e 's=#libexecdir#="$(LIBEXECDIR)"=g' -i $(OBJDIR)/docstubgen/docstubgen
 	install -m755 -d $(DESTDIR)$(PREFIX)/$(BINDIR)
 	install -m755 $(OBJDIR)/docstubgen/docstubgen $(DESTDIR)$(PREFIX)/$(BINDIR)
 	install -m755 -d $(DESTDIR)$(PREFIX)/$(LIBEXECDIR)

--- a/contributor-tools/Makefile
+++ b/contributor-tools/Makefile
@@ -10,20 +10,28 @@ LIBEXECDIR ?= libexec
 SHAREDIR ?= share
 OBJDIR ?= obj
 
-all: man
-man: build-docstubgen-manpage
-install: install-docstubgen install-docstubgen-compat-symlink
-install-man: install-docstubgen-man
+all: src man
+src: prep build-docstubgen
+man: prep build-docstubgen-manpage
+install: src install-docstubgen install-docstubgen-compat-symlink
+install-man: man install-docstubgen-man
 World: all install install-man
 
 clean:
 	rm -rf $(OBJDIR)
 
+prep:
+	mkdir -p $(OBJDIR)/docstubgen
+
 build-docstubgen-manpage: $(OBJDIR)/docstubgen/docstubgen.1
 $(OBJDIR)/docstubgen/docstubgen.1: docstubgen/docstubgen.1.xml
-	mkdir -p $(OBJDIR)/docstubgen/
 	xsltproc --output $(OBJDIR)/docstubgen/ $(XSLSTYLESHEET) docstubgen/docstubgen.1.xml
+
+build-docstubgen: $(OBJDIR)/docstubgen/docstubgen $(OBJDIR)/docstubgen/docstubgen-checkfile
+$(OBJDIR)/docstubgen/docstubgen: docstubgen/docstubgen FRC
 	cp docstubgen/docstubgen $(OBJDIR)/docstubgen/
+
+$(OBJDIR)/docstubgen/docstubgen-checkfile: docstubgen/docstubgen-checkfile FRC
 	cp docstubgen/docstubgen-checkfile $(OBJDIR)/docstubgen/
 
 install-docstubgen:
@@ -39,3 +47,5 @@ install-docstubgen-man: build-docstubgen-manpage
 
 install-docstubgen-compat-symlink: install-docstubgen
 	ln -sf docstubgen $(DESTDIR)$(PREFIX)/$(BINDIR)/generate-doc-stub.py
+
+FRC:

--- a/contributor-tools/docstubgen/docstubgen
+++ b/contributor-tools/docstubgen/docstubgen
@@ -34,8 +34,10 @@ trustedinputflag = False
 idontcareaboutsecurity = False
 
 def checklib(i, f):
-	return not (libdocflag and (".a" in os.path.basename(os.path.join(i, 
-		f)) or ".so" in os.path.basename(os.path.join(i, f))))
+	return (libdocflag and (".a" in os.path.basename(os.path.join(i, 
+		f)) or ".so" in os.path.basename(os.path.join(i, f)) or 
+		".jar" in os.path.basename(os.path.join(i, f)) or
+		".dll" in os.path.basename(os.path.join(i, f))))
 
 def callcheckfile(path):
 	if not checkbinflag:
@@ -95,6 +97,13 @@ for d in range(len(sys.argv)):
 	if d == 0 or d == 1:
 		continue
 	if recsearchflag:
+		# yes, this is a duplicate of the code from the next loop
+		# but we need it because os.walk apparently just ignores
+		# nonexistent folders, and because of that any missing folder
+		# errors were masked out in this case
+		if not os.path.isdir(sys.argv[d]):
+			print(f"Error: nonexistent folder {sys.argv[d]}", file=sys.stderr)
+			sys.exit(1)
 		for tmp in [x[0] for x in os.walk(sys.argv[d])]:
 			folderlist.append(tmp)
 	else:
@@ -116,7 +125,7 @@ for d in folderlist:
 			if os.path.isfile(os.path.normpath(os.path.join(os.path.dirname(os.path.join(i, \
 					f)), os.readlink(os.path.join(i, f))))):
 				if libdocflag:
-					if checklib(i, f) and callcheckfile(os.path.normpath(os.path.join(os.path.dirname(os.path.join(i, \
+					if not checklib(i, f) and callcheckfile(os.path.normpath(os.path.join(os.path.dirname(os.path.join(i, \
 							f)), os.readlink(os.path.join(i, f))))) == 0:
 						filelist.append([f, 's', os.path.basename(os.readlink( \
 							os.path.join(i, f)))])
@@ -127,7 +136,7 @@ for d in folderlist:
 								f)))])
 		elif os.path.isfile(os.path.join(i, f)):
 			if libdocflag:
-				if checklib(i, f) and callcheckfile(os.path.join(i, f)) == 0:
+				if not checklib(i, f) and callcheckfile(os.path.join(i, f)) == 0:
 					filelist.append([f, 'f', 'FILLER'])
 			else:
 				if callcheckfile(os.path.join(i, f)) == 0:
@@ -149,8 +158,6 @@ if libdocflag:
 				if os.path.isfile(os.path.normpath(os.path.join(os.path.dirname(os.path.join(i, \
 						f)), os.readlink(os.path.join(i, f))))):
 					continue
-			elif os.path.isfile(os.path.join(i, f)) and '.a' in os.path.basename(os.path.join(i, f)) and callcheckfile(os.path.join(i, f)) == 0:
-				liblist.append([f, 'f', 'FILLER'])
 			elif os.path.isfile(os.path.join(i, f)) and '.so' in os.path.basename(os.path.join(i, f)) and callcheckfile(os.path.join(i, f)) == 0:
 				tmplst = f.split('.')
 				tmp = tmplst[0]
@@ -161,6 +168,8 @@ if libdocflag:
 					if not h.isdigit():
 						tmp = tmp + '.' + h
 				liblist.append([tmp, 'f', 'FILLER'])
+			elif os.path.isfile(os.path.join(i, f)) and checklib(i, f) and callcheckfile(os.path.join(i, f)) == 0:
+				liblist.append([f, 'f', 'FILLER'])
 
 	liblist.sort()
 	liblist = list(liblist for liblist,_ in itertools.groupby(liblist))
@@ -212,7 +221,18 @@ if not libdocflag:
 else:
 	tmp = '          '
 	for i in liblist:
-		tmp2 = tmp + i[0] + ', '
+		if '.a' == i[0][-2:]:
+			f = i[0][:-2] + ' (static)'
+		elif '.so' == i[0][-3:]:
+			f = i[0][:-3]
+		elif '.jar' == i[0][-4:]:
+			f = i[0][:-4] + ' (Java library)'
+		elif '.dll' == i[0][-4:]:
+			f = i[0][:-4] + ' (DLL)'
+		else:
+			# what the???
+			f = i
+		tmp2 = tmp + f + ', '
 		#print(tmp2)
 		if len(tmp2) <= 80:
 			tmp = tmp2
@@ -298,30 +318,39 @@ for g in filelist:
       </varlistentry>
 ''', end='')
 
+printedout = []
 if libdocflag:
 	for g in liblist:
 		i = g[0]
 		# yes this is a hack
 		# but i can't figure out how rsplit works, I'm tired and it's 11:49PM
-		if '.a' in i:
+		if '.a' == i[-2:]:
 			f = i[:-2]
-		elif '.so' in i:
+		elif '.so' == i[-3:]:
 			f = i[:-3]
+		elif '.jar' == i[-4:]:
+			f = i[:-4]
+		elif '.dll' == i[-4:]:
+			f = i[:-4]
 		else:
+			# what the???
 			f = i
-		print(f'''
+		# teaching an old codebase new tricks :tm:
+		if f not in printedout:
+			print(f'''
       <varlistentry id="{f}">
-        <term><filename class="libraryfile">{i}</filename></term>
+        <term><filename class="libraryfile">{f}</filename></term>
         <listitem>
           <para>
             TODO
           </para>
           <indexterm zone="{sys.argv[1]} {f}">
-            <primary sortas="c-{f}">{i}</primary>
+            <primary sortas="c-{f}">{f}</primary>
           </indexterm>
         </listitem>
       </varlistentry>
 ''', end='')
+			printedout.append(f)
 
 print('''
     </variablelist>

--- a/contributor-tools/docstubgen/docstubgen-checkfile
+++ b/contributor-tools/docstubgen/docstubgen-checkfile
@@ -3,11 +3,21 @@
 # Helper script for checking files in docstubgen.
 # (C) Seal Sealy 2025
 
+# JARs are actually internally ZIP archives... sigh
+
+if [ "${1##*.}" = "jar" ]; then
+	file $1 | grep -E "Zip" > /dev/null 2>&1
+	if [ $? -eq 0 ]; then
+		exit 0
+	fi
+fi 
+
 # ELF is binaries and shared libraries
 # scripts is all kinds of misc .sh stuff and more
 # ar archive is for static libs
+# DLL is Windows DLLs
 
-file $1 | grep -E "ELF|script|ar archive" > /dev/null 2>&1
+file $1 | grep -E "ELF|script|ar archive|DLL" > /dev/null 2>&1
 if [ $? -ne 0 ]; then
 	exit 1
 fi

--- a/contributor-tools/docstubgen/docstubgen.1.xml
+++ b/contributor-tools/docstubgen/docstubgen.1.xml
@@ -7,7 +7,7 @@
 <refmeta>
 <refentrytitle>docstubgen</refentrytitle>
 <manvolnum>1</manvolnum>
-<refmiscinfo class='source'>March 12, 2025</refmiscinfo>
+<refmiscinfo class='source'>April 12, 2025</refmiscinfo>
 <refmiscinfo class='manual'>LFS-QOL Contributor Tools</refmiscinfo>
 </refmeta>
 <refnamediv>
@@ -58,8 +58,8 @@ In order to not break any existing workflows, these features are all guarded beh
   <varlistentry>
   <term><emphasis role='strong' remap='B'>DOCSTUBGEN_DOCUMENT_LIBRARIES</emphasis></term>
   <listitem>
-<para>Enables library documenting. Current mechanism for checking if a file is a library or not checks if the
-string ".a" or ".so" appears in the filename.</para>
+<para>Enables library documenting. Current mechanism for checking if a file is a library or not checks if ".a", ".so", ".jar"
+or ".dll" appears in the filename.</para>
   </listitem>
   </varlistentry>
   <varlistentry>
@@ -85,8 +85,8 @@ string ".a" or ".so" appears in the filename.</para>
   <listitem>
 <para>Performs a binary detection to check if a file is a binary or just some accompanying auxilliary file
 that randomly got put in the folders. Current mechanism for checking this involves executing the file
-command on every single file in the folders and checking if the output contains "ELF", "script", or
-"ar archive".</para>
+command on every single file in the folders and checking if the output contains "ELF", "script", "DLL", or
+"ar archive" OR the output contains "Zip" while the extension is ".jar".</para>
   </listitem>
   </varlistentry>
   <varlistentry>


### PR DESCRIPTION
This PR fixes some minor bugs in docstubgen and adapts it to the new library documentation notation.

Open to any changes.