### PR TITLE
Makefile: Display a file:// URL for the newly rendered book's index.html

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,16 @@ $(BASEDIR)/index.html: $(RENDERTMP)/$(LFS_QOLHTML) version wget-list
 
 	$(Q)$(CLEAN)
 
+# Display a URL for the newly-rendered index.html, accounting for a relative
+# $(BASEDIR)
+	$(Q)echo
+	$(Q)if echo "$(BASEDIR)" | grep -q '^/'; then \
+		echo "View the book at file://$(BASEDIR)/index.html"; \
+	else \
+	   echo "View the book at file://$$PWD/$(BASEDIR)/index.html"; \
+	fi;
+	$(Q)echo
+
 validate: $(RENDERTMP)/$(LFS_QOLFULL)
 $(RENDERTMP)/$(LFS_QOLFULL): general.ent packages.ent $(ALLXML) $(ALLXSL) version
 	$(Q)[ -d $(RENDERTMP) ] || mkdir -p $(RENDERTMP)


### PR DESCRIPTION
Hey,

I find it useful to know where the book has been rendered to, so I added a few lines to the Makefile to display a URL for the book. I'm submitting a PR since this might be helpful to other readers. Let me know what you think :) 

Also, there's probably a better POSIX-compliant way to check whether a path is absolute, but I just settled for grep since it's easy.

Thanks