### PR TITLE
fastfetch: 2.42.0 -> 2.43.0. Fixes #159

### DIFF
--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -41,6 +41,16 @@
     -->
 
     <listitem>
+      <para>May 28th, 2025</para>
+      <itemizedlist>
+        <listitem>
+          <para>[Toxikuu] - fastfetch: 2.42.0 -&gt; 2.43.0. Fixes
+          <ulink url="&lfs-qol-issues;/159">#159</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>May 25th, 2025</para>
       <itemizedlist>
         <listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -59,7 +59,7 @@ version, so keep this at that. -->
 <!ENTITY mesa-demos-version                  "9.0.0">
 <!ENTITY ncompress-version                   "5.0">
 <!ENTITY neofetch-version                    "7.1.0">
-<!ENTITY fastfetch-version                   "2.42.0">
+<!ENTITY fastfetch-version                   "2.43.0">
 <!ENTITY obs-studio-version                  "31.0.3">
 <!ENTITY obs-cef-version                     "6533">
 <!ENTITY rpmextract-version                  "1.0">


### PR DESCRIPTION
There may be a conflict in the changelog if #169 is merged as well.