### PR TITLE
Update multiple packages (and fix some bitrot in Binary Support)

### DIFF
--- a/binary/binary/fuse2.xml
+++ b/binary/binary/fuse2.xml
@@ -76,7 +76,7 @@
     </para>
 
 <screen><userinput>patch -Np1 -i ../conditionally-define-closefrom.patch &amp;&amp;
-autoreconf -i</userinput></screen>
+autoreconf -i -I/usr/share/gettext/m4</userinput></screen>
 
     <para>
       Install <application>Fuse2</application> by running the following

--- a/binary/binary/ostree.xml
+++ b/binary/binary/ostree.xml
@@ -45,10 +45,14 @@
     <bridgehead renderas="sect4">Recommended</bridgehead>
     <para role="recommended">
       <ulink url="&blfs-svn;/general/gtk-doc.html">GTK-Doc</ulink>,
-      <ulink url="&blfs-svn;/basicnet/libsoup.html">libsoup</ulink>,
       <ulink url="&blfs-svn;/basicnet/libsoup3.html">libsoup3</ulink>,
       <ulink url="&blfs-svn;/general/libxslt.html">libxslt</ulink>, and
       &logind-nocomma;
+    </para>
+
+    <bridgehead renderas="sect4">Optional</bridgehead>
+    <para role="optional">
+      <ulink url="https://linuxfromscratch.org/blfs/view/12.3/basicnet/libsoup.html">libsoup</ulink>
     </para>
 
   </sect2>

--- a/general/genlib/libutempter.xml
+++ b/general/genlib/libutempter.xml
@@ -4,7 +4,7 @@
   <!ENTITY % general-entities SYSTEM "../../general.ent">
   %general-entities;
 
-  <!ENTITY libutempter-download-http "http://ftp.altlinux.org/pub/people/ldv/libutempter/libutempter-&libutempter-version;.tar.gz">
+  <!ENTITY libutempter-download-http "https://github.com/altlinux/libutempter/archive/&libutempter-tag;/libutempter-&libutempter-tag;.tar.gz">
 ]>
 
 <sect1 id="libutempter" xreflabel="libutempter-&libutempter-version;">
@@ -24,7 +24,6 @@
       that allows non-privileged apps to write utmp info.
     </para>
 
-    
     <itemizedlist spacing="compact">
       <listitem>
         <para>
@@ -33,6 +32,16 @@
       </listitem>
     </itemizedlist>
    
+    <bridgehead renderas="sect3">Additional Downloads</bridgehead>
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          Required patch:
+          <ulink url="&patch-root;/libutempter/libutempter-&libutempter-version;-unbreak-reinstall.patch"/>
+        </para>
+      </listitem>
+    </itemizedlist>
+
   </sect2>
 
   <sect2 role="installation">
@@ -43,24 +52,15 @@
       commands:
     </para>
 
-<screen><userinput>make</userinput></screen>
+<screen><userinput>patch -Np1 -i ../libutempter-1.2.3-unbreak-reinstall.patch &amp;&amp;
+cd libutempter &amp;&amp;
+make</userinput></screen>
 
     <para>
       Now as the &root; user:
     </para>
 
-<screen role="root"><userinput>make install &amp;&amp;
-rm -vf /usr/lib/libutempter.a</userinput></screen>
-
-  </sect2>
-
-  <sect2 role="commands">
-    <title>Command Explanations</title>
-
-    <para>
-      <command>rm -vf /usr/lib/libutempter.a</command>: Remove a useless
-      static library.
-    </para>
+<screen role="root"><userinput>make install</userinput></screen>
 
   </sect2>
 

--- a/general/launch/rofi.xml
+++ b/general/launch/rofi.xml
@@ -5,13 +5,13 @@
   %general-entities;
 
   <!ENTITY rofi-download-http
-    "https://github.com/davatorium/rofi/releases/download/&rofi-version;/rofi-&rofi-version;.tar.xz">
+    "https://github.com/davatorium/rofi/releases/download/&rofi-version;/rofi-&rofi-full-version;.tar.xz">
 ]>
 
-<sect1 id="rofi" xreflabel="Rofi-&rofi-version;">
+<sect1 id="rofi" xreflabel="Rofi-&rofi-full-version;">
   <?dbhtml filename="rofi.html"?>
 
-  <title>Rofi-&rofi-version;</title>
+  <title>Rofi-&rofi-full-version;</title>
 
   <indexterm zone="rofi">
     <primary sortas="a-rofi">Rofi</primary>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -44,6 +44,10 @@
       <para>May 30th, 2025</para>
       <itemizedlist>
         <listitem>
+          <para>[seal331] - libutempter: 1.2.1 -&gt; 1.2.3.
+          Fixes <ulink url="&lfs-qol-issues;/164">#164</ulink>.</para>
+        </listitem>
+        <listitem>
           <para>[seal331] - Rofi-Wayland: 1.7.8+wayland1 -&gt; 1.7.9+wayland1.
           Fixes <ulink url="&lfs-qol-issues;/167">#167</ulink>.</para>
         </listitem>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -44,6 +44,10 @@
       <para>May 30th, 2025</para>
       <itemizedlist>
         <listitem>
+          <para>[seal331] - glaze: 5.1.0 -&gt; 5.3.0.
+          Fixes <ulink url="&lfs-qol-issues;/163">#163</ulink>.</para>
+        </listitem>
+        <listitem>
           <para>[seal331] - libzip: 1.11.3 -&gt; 1.11.4.
           Fixes <ulink url="&lfs-qol-issues;/165">#165</ulink>.</para>
         </listitem>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -41,6 +41,16 @@
     -->
 
     <listitem>
+      <para>May 30th, 2025</para>
+      <itemizedlist>
+        <listitem>
+          <para>[seal331] - foot: 1.22.0 -&gt; 1.22.3. Fixes
+          <ulink url="&lfs-qol-issues;/162">#162</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>May 28th, 2025</para>
       <itemizedlist>
         <listitem>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -44,6 +44,10 @@
       <para>May 30th, 2025</para>
       <itemizedlist>
         <listitem>
+          <para>[seal331] - flatpak: 1.16.0 -&gt; 1.16.1.
+          Fixes <ulink url="&lfs-qol-issues;/147">#147</ulink>.</para>
+        </listitem>
+        <listitem>
           <para>[seal331] - glaze: 5.1.0 -&gt; 5.3.0.
           Fixes <ulink url="&lfs-qol-issues;/163">#163</ulink>.</para>
         </listitem>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -44,6 +44,10 @@
       <para>May 30th, 2025</para>
       <itemizedlist>
         <listitem>
+          <para>[seal331] - libzip: 1.11.3 -&gt; 1.11.4.
+          Fixes <ulink url="&lfs-qol-issues;/165">#165</ulink>.</para>
+        </listitem>
+        <listitem>
           <para>[seal331] - libutempter: 1.2.1 -&gt; 1.2.3.
           Fixes <ulink url="&lfs-qol-issues;/164">#164</ulink>.</para>
         </listitem>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -44,6 +44,14 @@
       <para>May 30th, 2025</para>
       <itemizedlist>
         <listitem>
+          <para>[seal331] - Rofi-Wayland: 1.7.8+wayland1 -&gt; 1.7.9+wayland1.
+          Fixes <ulink url="&lfs-qol-issues;/167">#167</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[seal331] - Rofi: 1.7.8 -&gt; 1.7.9.1. Fixes
+          <ulink url="&lfs-qol-issues;/166">#166</ulink>.</para>
+        </listitem>
+        <listitem>
           <para>[seal331] - foot: 1.22.0 -&gt; 1.22.3. Fixes
           <ulink url="&lfs-qol-issues;/162">#162</ulink>.</para>
         </listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -10,7 +10,8 @@
 <!ENTITY libdatachannel-version              "0.22.6">
 <!ENTITY libdatachannel-plog                 "94899e0b926ac1b0f4750bfbd495167b4a6ae9ef">
 <!ENTITY libdatachannel-usrsctp              "ebb18adac6501bad4501b1f6dccb67a1c85cc299">
-<!ENTITY libutempter-version                 "1.2.1">
+<!ENTITY libutempter-version                 "1.2.3">
+<!ENTITY libutempter-tag                     "&libutempter-version;-alt1">
 <!ENTITY libzip-version                      "1.11.3">
 <!ENTITY mbedtls-version                     "3.6.3">
 <!ENTITY zlib-version                        "1.3.1">

--- a/packages.ent
+++ b/packages.ent
@@ -102,7 +102,15 @@ version, so keep this at that. -->
 <!ENTITY alacritty-version                   "0.15.1">
 <!ENTITY foot-version                        "1.22.3">
 <!-- Launchers -->
-<!ENTITY rofi-version                        "1.7.8">
+<!-- According to upstream, 1.7.9.1 was "just a tarball fix, no code change".
+As a side effect of that they just slapped the 1.7.9.1 tarballs in the 1.7.9
+release, and the original 1.7.9 tarballs are no longer available AFAICS.
+So now we have to deal with this. Once rofi updates again to something with a
+saner tag/tarball version relationship just get rid of this both here and in
+general/launch/rofi.xml. At least it's better than three separate versions with
+the exact same version number... -->
+<!ENTITY rofi-full-version                   "1.7.9.1">
+<!ENTITY rofi-version                        "1.7.9">
 <!ENTITY rofi-wayland-version                "&rofi-version;+wayland1">
 <!ENTITY wofi-version                        "1.4.1">
 

--- a/packages.ent
+++ b/packages.ent
@@ -133,7 +133,7 @@ the exact same version number... -->
 <!-- Binary Support -->
 <!ENTITY fuse2-version                       "2.9.9">
 <!ENTITY ostree-version                      "2025.2">
-<!ENTITY flatpak-version                     "1.16.0">
+<!ENTITY flatpak-version                     "1.16.1">
 
 <!-- WM -->
 <!-- CDE -->

--- a/packages.ent
+++ b/packages.ent
@@ -100,7 +100,7 @@ version, so keep this at that. -->
 <!ENTITY xeyes-version                       "1.3.0">
 <!-- Terminal Emulators -->
 <!ENTITY alacritty-version                   "0.15.1">
-<!ENTITY foot-version                        "1.22.0">
+<!ENTITY foot-version                        "1.22.3">
 <!-- Launchers -->
 <!ENTITY rofi-version                        "1.7.8">
 <!ENTITY rofi-wayland-version                "&rofi-version;+wayland1">

--- a/packages.ent
+++ b/packages.ent
@@ -2,7 +2,7 @@
 <!-- General Libraries -->
 <!ENTITY asio-version                        "1-34-2">
 <!ENTITY enet-version                        "1.3.18">
-<!ENTITY glaze-version                       "5.1.0">
+<!ENTITY glaze-version                       "5.3.0">
 <!ENTITY iniparser-version                   "4.2.6">
 <!ENTITY libev-version                       "4.33">
 <!ENTITY libjuice-version                    "1.6.0">

--- a/packages.ent
+++ b/packages.ent
@@ -12,7 +12,7 @@
 <!ENTITY libdatachannel-usrsctp              "ebb18adac6501bad4501b1f6dccb67a1c85cc299">
 <!ENTITY libutempter-version                 "1.2.3">
 <!ENTITY libutempter-tag                     "&libutempter-version;-alt1">
-<!ENTITY libzip-version                      "1.11.3">
+<!ENTITY libzip-version                      "1.11.4">
 <!ENTITY mbedtls-version                     "3.6.3">
 <!ENTITY zlib-version                        "1.3.1">
 <!ENTITY nlohmann-json-version               "3.12.0">

--- a/patches/libutempter/libutempter-1.2.3-unbreak-reinstall.patch
+++ b/patches/libutempter/libutempter-1.2.3-unbreak-reinstall.patch
@@ -1,0 +1,30 @@
+From cc98405e5a7eb1d07e91a63f5e80f47e2c498ebf Mon Sep 17 00:00:00 2001
+From: Adam Duskett <adam.duskett@amarulasolutions.com>
+Date: Wed, 22 Nov 2023 14:15:28 -0700
+Subject: [PATCH] force symlink creation
+
+Force symlink creation to avoid errors when reinstalling.
+---
+ libutempter/Makefile | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/libutempter/Makefile b/libutempter/Makefile
+index 256f1f8..a12fa13 100644
+--- a/libutempter/Makefile
++++ b/libutempter/Makefile
+@@ -82,12 +82,12 @@ install:
+ 	$(INSTALL) -p -m2711 $(PROJECT) $(DESTDIR)$(libexecdir)/$(PROJECT)/
+ 	$(INSTALL) -p -m644 $(PROJECT).h $(DESTDIR)$(includedir)/
+ 	$(INSTALL) -p -m755 $(SHAREDLIB) $(DESTDIR)$(libdir)/$(SHAREDLIB).$(VERSION)
+-	ln -s $(SHAREDLIB).$(VERSION) $(DESTDIR)$(libdir)/$(SONAME)
+-	ln -s $(SONAME) $(DESTDIR)$(libdir)/$(SHAREDLIB)
++	ln -sf $(SHAREDLIB).$(VERSION) $(DESTDIR)$(libdir)/$(SONAME)
++	ln -sf $(SONAME) $(DESTDIR)$(libdir)/$(SHAREDLIB)
+ 	$(INSTALL) -p -m644 $(PROJECT).3 $(DESTDIR)$(man3dir)/
+ 	for n in lib$(PROJECT) utempter_add_record utempter_remove_record \
+ 	    utempter_remove_added_record utempter_set_helper; do \
+-		ln -s $(PROJECT).3 $(DESTDIR)$(man3dir)/$$n.3; \
++		ln -sf $(PROJECT).3 $(DESTDIR)$(man3dir)/$$n.3; \
+ 	done
+ 
+ clean:


### PR DESCRIPTION
This PR closes all known "update package" tickets and fixes some minor bitrot (a breakage in FUSE2 because some gettext m4 files moved and a dead link in OSTree) in the Binary Support chapter.

Open to any changes.

Fixes #147.
Fixes #162.
Fixes #163.
Fixes #164.
Fixes #165.
Fixes #166.
Fixes #167.