### PR TITLE
eza: Simplify and improve man pages download instructions

### DIFF
--- a/general/sysutils/eza.xml
+++ b/general/sysutils/eza.xml
@@ -83,11 +83,10 @@
     </para>
 
 <screen remap="doc"
-  role="root"><userinput>curl -L &eza-man-dl; \
-  -o eza-man-&eza-version;.tar.gz &amp;&amp;
-tar -xf eza-man-&eza-version;.tar.gz &amp;&amp;
+  role="root"><userinput>curl -fsSL &eza-man-dl; |
+  tar -xzvf - &amp;&amp;
 for i in {1,5}; do
-  cp -v target/man-&eza-version;/*.$i /usr/share/man/man$i
+  install -vDm644 target/man-&eza-version;/*.$i -t /usr/share/man/man$i/
 done</userinput></screen>
 
   </sect2>


### PR DESCRIPTION
Since `curl` writes to stdout by default, we may as well make use of that to avoid writing a transient tarball. I've also passed `-f` to `curl`, which is good practice. This should also be done for `cargo-c` in `BLFS`[^1].

I switched from `cp -v` to `install -vDm644` as it's both more explicit and accounts for the case where any parent directories don't exist.

[^1]: The case with `cargo-c` is especially important, as a silent `curl` failure would cause `Cargo.lock` to be generated by `cargo build --release` instead, which would be **not good** for reasons explained on that page.