### PR TITLE
socat: Add an optional external dependency on TCP Wrappers.

### DIFF
--- a/general/prog/socat.xml
+++ b/general/prog/socat.xml
@@ -33,6 +33,13 @@
       </listitem>
     </itemizedlist>
 
+    <bridgehead renderas="sect3">socat Dependencies</bridgehead>
+
+    <bridgehead renderas="sect4">Optional</bridgehead>
+    <para role="optional">
+      <ulink url="https://packages.debian.org/sid/libwrap0">tcp-wrappers</ulink>
+    </para>
+
   </sect2>
 
   <sect2 role="installation">


### PR DESCRIPTION
I discovered this while reading through the configure output. I needed this package for some debugging I needed to do on Netatalk, and that also uses TCP Wrappers...

Note that TCP Wrappers is often just called libwrap0