### PR TITLE
obs-studio: use Intel Media Driver instead of Intel VAAPI Driver.

### DIFF
--- a/graph/app/obs-studio.xml
+++ b/graph/app/obs-studio.xml
@@ -111,7 +111,7 @@
         </listitem>
         <listitem>
           <para>
-            <ulink url="&blfs-svn;/multimedia/intel-vaapi-driver.html">intel-vaapi-driver</ulink>
+            <ulink url="&blfs-svn;/multimedia/intel-media-driver.html">intel-media-driver</ulink>
             and
             <ulink url="&blfs-svn;/x/mesa.html">Mesa</ulink>
             (required for Intel QSV11 hardware encoding)


### PR DESCRIPTION
The Intel VAAPI Driver is only designed for cards from Haswell CPUs and lower, and the driver does not support any of the modern encoding standards that OBS is going to try to use.

The Intel Media Driver supports Broadwell and later, including the most recent GPUs. This is what OBS is going to want, and we'll need to add some additional packages to actually make this work.

For now though let's get the right VA-API driver in