### PR TITLE
Shorten URLs containing /archive/refs/tags to /archive

### DIFF
--- a/general/genlib/asio.xml
+++ b/general/genlib/asio.xml
@@ -5,7 +5,7 @@
   %general-entities;
 
   <!ENTITY asio-download-http
-    "https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-&asio-version;.tar.gz">
+    "https://github.com/chriskohlhoff/asio/archive/asio-&asio-version;.tar.gz">
 ]>
 
 <sect1 id="asio" xreflabel="asio-&asio-version;">

--- a/general/genlib/yajl.xml
+++ b/general/genlib/yajl.xml
@@ -5,7 +5,7 @@
   %general-entities;
 
   <!ENTITY yajl-download-http
-    "https://github.com/lloyd/yajl/archive/refs/tags/&yajl-version;/yajl-&yajl-version;.tar.gz">
+    "https://github.com/lloyd/yajl/archive/&yajl-version;/yajl-&yajl-version;.tar.gz">
 ]>
 
 <sect1 id="yajl" xreflabel="yajl-&yajl-version;">


### PR DESCRIPTION
These URLs may be shortened. It's a small style/consistency tweak.