### PR TITLE
Add msgraph to SLFS.

### DIFF
--- a/general.ent
+++ b/general.ent
@@ -36,7 +36,7 @@
 ]]><!-- End %release -->
 
 <!-- Include the GNOME entities -->
-<!ENTITY % gnome-entities SYSTEM       "gnome.ent"
+<!ENTITY % gnome-entities SYSTEM       "gnome.ent">
 %gnome-entities;
 
 <!ENTITY copyrightdate   "2024-&year;">

--- a/general.ent
+++ b/general.ent
@@ -93,6 +93,8 @@
 <!ENTITY w3m-url              "http://w3m.sourceforge.net/">
 <!ENTITY sysprof-url          "https://wiki.gnome.org/Apps/Sysprof">
 <!ENTITY man                  "https://man.archlinux.org/man/">
+<!ENTITY gnome-download-http  "https://download.gnome.org/sources">
+
 
 <!ENTITY slfs-repo            "https://github.com/glfs-book/slfs">
 <!ENTITY slfs-issues          "&slfs-repo;/issues">

--- a/general.ent
+++ b/general.ent
@@ -35,6 +35,10 @@
 ]]>
 ]]><!-- End %release -->
 
+<!-- Include the GNOME entities -->
+<!ENTITY % gnome-entities SYSTEM       "gnome.ent"
+%gnome-entities;
+
 <!ENTITY copyrightdate   "2024-&year;">
 <!ENTITY copyholder      "The GLFS Development Team">
 <!ENTITY lfs-domainname  "linuxfromscratch.org">
@@ -93,7 +97,6 @@
 <!ENTITY w3m-url              "http://w3m.sourceforge.net/">
 <!ENTITY sysprof-url          "https://wiki.gnome.org/Apps/Sysprof">
 <!ENTITY man                  "https://man.archlinux.org/man/">
-<!ENTITY gnome-download-http  "https://download.gnome.org/sources">
 
 
 <!ENTITY slfs-repo            "https://github.com/glfs-book/slfs">

--- a/general/genlib/genlib.xml
+++ b/general/genlib/genlib.xml
@@ -31,6 +31,7 @@
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="m17n.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="mbedtls.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="minizip.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="msgraph.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="nlohmann-json.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="pugixml.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="qrcodegencpp.xml"/>

--- a/general/genlib/msgraph.xml
+++ b/general/genlib/msgraph.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sect1 PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+   "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+  <!ENTITY % general-entities SYSTEM "../../general.ent">
+  %general-entities;
+
+  <!ENTITY gnome-download-http  "https://download.gnome.org/sources">
+  <!ENTITY msgraph-download-http "&gnome-download-http;/msgraph/0.3/msgraph-&msgraph-version;.tar.xz">
+]>
+
+<sect1 id="msgraph" xreflabel="msgraph-&msgraph-version;">
+
+  <?dbhtml filename="msgraph.html"?>
+  
+  <title>msgraph-&msgraph-version;</title>
+
+  <indexterm zone="msgraph">
+    <primary sortas="a-msgraph">msgraph</primary>
+  </indexterm>
+
+  <sect2 role="package">
+    <title>Introduction to msgraph</title>
+
+    <para>
+      The msgraph package contains a shared library for accessing the Microsoft
+      Graph API. This is useful for adding support for OneDrive into gvfs,
+      which is becoming more important for students and remote workers.
+    </para>
+
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          Download (HTTP): <ulink url="&msgraph-download-http;"/>
+        </para>
+      </listitem>
+    </itemizedlist>
+
+    <bridgehead renderas="sect3">msgraph Dependencies</bridgehead>
+
+    <bridgehead renderas="sect4">Required</bridgehead>
+    <para role="required">
+      <!-- The remainder of the dependencies are all required by g-o-a.
+           This includes libsoup, libxml2, json-glib, and glib. -->
+      <ulink url="&blfs-svn;/gnome/gnome-online-accounts.html">gnome-online-accounts</ulink>
+    </para>
+
+    <bridgehead renderas="sect4">Optional</bridgehead>
+    <para role="optional">
+      <ulink url="https://gitlab.freedesktop.org/pwithnall/uhttpmock">uhttpmock (for tests)</ulink>
+    </para>
+
+  </sect2>
+
+  <sect2 role="installation">
+    <title>Installation of msgraph</title>
+
+    <para>
+      Install msgraph by running the following
+      commands:
+    </para>
+
+<screen><userinput>mkdir build &amp;&amp;
+cd    build &amp;&amp;
+
+meson setup --prefix=/usr --buildtype=release -Dtests=false .. &amp;&amp;
+ninja</userinput></screen>
+
+    <para>
+      This package does come with a test suite, but it requires the external
+      program
+      <ulink url="https://gitlab.freedesktop.org/pwithnall/uhttpmock">uhttpmock</ulink>.
+      If you want to run the tests, install uhttpmock and remove -Dtests=false,
+      and then run <command>ninja test</command>
+    </para>
+
+    <para>
+      Now, as the &root; user:
+    </para>
+
+<screen role="root"><userinput>ninja install</userinput></screen>
+
+  </sect2>
+
+  <sect2 role="using">
+    <title>Using msgraph</title>
+
+    <para>
+      To configure msgraph to allow access to Microsoft OneDrive with packages
+      that use gvfs, you should rebuild gvfs in BLFS without the
+      <parameter>-Donedrive=false</parameter> option. After doing this, you
+      should go to GNOME Control Center/GNOME Settings and link your
+      Microsoft account through the Online Accounts section, and you should
+      be able to mount your OneDrive file storage account in Nautilus.
+    </para>
+  </sect2>
+
+  <sect2 role="content">
+    <title>Contents</title>
+
+    <segmentedlist>
+      <segtitle>Installed Programs</segtitle>
+      <segtitle>Installed Libraries</segtitle>
+      <segtitle>Installed Directories</segtitle>
+
+      <seglistitem>
+        <seg>
+          None
+        </seg>
+        <seg>
+          libmsgraph-1.so
+        </seg>
+        <seg>
+          /usr/include/msg and
+          /usr/share/doc/msgraph-&msgraph-version;
+        </seg>
+      </seglistitem>
+    </segmentedlist>
+
+    <variablelist>
+      <bridgehead renderas="sect3">Short Descriptions</bridgehead>
+      <?dbfo list-presentation="list"?>
+      <?dbhtml list-presentation="table"?>
+
+      <varlistentry id="libmsgraph">
+        <term><filename class="libraryfile">libmsgraph-1.so</filename></term>
+        <listitem>
+          <para>
+            contains functions that allow applications to interact with the
+            Microsoft Graph API.
+          </para>
+          <indexterm zone="msgraph libmsgraph">
+            <primary sortas="c-libmsgraph">libmsgraph-1.so</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </sect2>
+</sect1>

--- a/general/genlib/msgraph.xml
+++ b/general/genlib/msgraph.xml
@@ -4,7 +4,6 @@
   <!ENTITY % general-entities SYSTEM "../../general.ent">
   %general-entities;
 
-  <!ENTITY gnome-download-http  "https://download.gnome.org/sources">
   <!ENTITY msgraph-download-http "&gnome-download-http;/msgraph/0.3/msgraph-&msgraph-version;.tar.xz">
 ]>
 
@@ -62,15 +61,15 @@
 <screen><userinput>mkdir build &amp;&amp;
 cd    build &amp;&amp;
 
-meson setup --prefix=/usr --buildtype=release -Dtests=false .. &amp;&amp;
+meson setup --prefix=/usr --buildtype=release -D tests=false .. &amp;&amp;
 ninja</userinput></screen>
 
     <para>
       This package does come with a test suite, but it requires the external
       program
       <ulink url="https://gitlab.freedesktop.org/pwithnall/uhttpmock">uhttpmock</ulink>.
-      If you want to run the tests, install uhttpmock and remove -Dtests=false,
-      and then run <command>ninja test</command>
+      If you want to run the tests, install uhttpmock and remove -D tests=false,
+      and then run <command>ninja test</command>.
     </para>
 
     <para>
@@ -87,7 +86,7 @@ ninja</userinput></screen>
     <para>
       To configure msgraph to allow access to Microsoft OneDrive with packages
       that use gvfs, you should rebuild gvfs in BLFS without the
-      <parameter>-Donedrive=false</parameter> option. After doing this, you
+      <parameter>-D onedrive=false</parameter> option. After doing this, you
       should go to GNOME Control Center/GNOME Settings and link your
       Microsoft account through the Online Accounts section, and you should
       be able to mount your OneDrive file storage account in Nautilus.
@@ -107,7 +106,7 @@ ninja</userinput></screen>
           None
         </seg>
         <seg>
-          libmsgraph-1.so
+          libmsgraph-1
         </seg>
         <seg>
           /usr/include/msg and
@@ -122,14 +121,14 @@ ninja</userinput></screen>
       <?dbhtml list-presentation="table"?>
 
       <varlistentry id="libmsgraph">
-        <term><filename class="libraryfile">libmsgraph-1.so</filename></term>
+        <term><filename class="libraryfile">libmsgraph-1</filename></term>
         <listitem>
           <para>
             contains functions that allow applications to interact with the
             Microsoft Graph API.
           </para>
           <indexterm zone="msgraph libmsgraph">
-            <primary sortas="c-libmsgraph">libmsgraph-1.so</primary>
+            <primary sortas="c-libmsgraph">libmsgraph-1</primary>
           </indexterm>
         </listitem>
       </varlistentry>

--- a/general/genlib/msgraph.xml
+++ b/general/genlib/msgraph.xml
@@ -68,8 +68,9 @@ ninja</userinput></screen>
       This package does come with a test suite, but it requires the external
       program
       <ulink url="https://gitlab.freedesktop.org/pwithnall/uhttpmock">uhttpmock</ulink>.
-      If you want to run the tests, install uhttpmock and remove -D tests=false,
-      and then run <command>ninja test</command>.
+      If you want to run the tests, install uhttpmock and remove the
+      <parameter>-D tests=false</parameter> parameter, and then run
+      <command>ninja test</command>.
     </para>
 
     <para>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -44,6 +44,9 @@
       <para>August 6th, 2025</para>
       <itemizedlist>
         <listitem>
+          <para>[renodr] - msgraph: Added.</para>
+        </listitem>
+        <listitem>
           <para>[seal331] - C-INTERCAL: Archived.</para>
         </listitem>
       </itemizedlist>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -44,7 +44,8 @@
       <para>August 6th, 2025</para>
       <itemizedlist>
         <listitem>
-          <para>[renodr] - msgraph: Added.</para>
+          <para>[renodr] - msgraph: Added. Fixes
+          <ulink url="&slfs-issues;/177">#177</ulink>.</para>
         </listitem>
         <listitem>
           <para>[seal331] - C-INTERCAL: Archived.</para>

--- a/packages.ent
+++ b/packages.ent
@@ -20,6 +20,7 @@
 <!ENTITY m17n-version                        "1.8.5">
 <!ENTITY m17n-db-version                     "1.8.10">
 <!ENTITY mbedtls-version                     "3.6.4">
+<!ENTITY msgraph-version                     "0.3.3">
 <!ENTITY zlib-version                        "1.3.1">
 <!ENTITY nlohmann-json-version               "3.12.0">
 <!ENTITY pugixml-version                     "1.15">


### PR DESCRIPTION
This package is useful for students and remote workers who need to interact with the Microsoft ecosystem. OneDrive support has been added as default in Windows 11 for a long time now, so this allows users on Linux to be able to access files from Windows machines that get automatically backed up to OneDrive.

Users who install this will need to rebuild gvfs in BLFS without the -Donedrive=false option. I've added some basic usage information into the page as well to that effect!

Fixes #177 