### PR TITLE
Add three new packages

### DIFF
--- a/general/genutils/genutils.xml
+++ b/general/genutils/genutils.xml
@@ -25,6 +25,7 @@
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="lrzsz.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="minicom.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="gkermit.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ncdu.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ncompress.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="neofetch.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="fastfetch.xml"/>

--- a/general/genutils/ncdu.xml
+++ b/general/genutils/ncdu.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sect1 PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+   "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+  <!ENTITY % general-entities SYSTEM "../../general.ent">
+  %general-entities;
+
+  <!ENTITY ncdu-download-http "https://dev.yorhel.nl/download/ncdu-&ncdu-version;.tar.gz">
+]>
+
+<sect1 id="ncdu" xreflabel="ncdu-&ncdu-version;">
+  <?dbhtml filename="ncdu.html"?>
+
+  <title>ncdu-&ncdu-version;</title>
+
+  <indexterm zone="ncdu">
+    <primary sortas="a-ncdu">ncdu</primary>
+  </indexterm>
+
+  <sect2 role="package">
+    <title>Introduction to ncdu</title>
+
+    <para>
+      The ncdu package provides a lightweight ncurses-based disk space analyzer.
+    </para>
+
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          Download (HTTP): <ulink url="&ncdu-download-http;"/>
+        </para>
+      </listitem>
+    </itemizedlist>
+   
+  </sect2>
+
+  <sect2 role="installation">
+    <title>Installation of ncdu</title>
+
+    <para>
+      Install ncdu by executing the following commands:
+    </para>
+
+<screen><userinput>./configure --prefix=/usr &amp;&amp;
+make</userinput></screen>
+
+    <para>
+      Now as the &root; user:
+    </para>
+
+<screen role="root"><userinput>make install</userinput></screen>
+
+  </sect2>
+
+  <sect2 role="content">
+    <title>Contents</title>
+
+    <segmentedlist>
+      <segtitle>Installed Programs</segtitle>
+      <segtitle>Installed Libraries</segtitle>
+      <segtitle>Installed Directories</segtitle>
+
+      <seglistitem>
+        <seg>
+          ncdu
+        </seg>
+        <seg>
+          None
+        </seg>
+        <seg>
+          None
+        </seg>
+      </seglistitem>
+    </segmentedlist>
+
+    <variablelist>
+      <bridgehead renderas="sect3">Short Descriptions</bridgehead>
+      <?dbfo list-presentation="list"?>
+      <?dbhtml list-presentation="table"?>
+
+      <varlistentry id="ncdu-bin">
+        <term><command>ncdu</command></term>
+        <listitem>
+          <para>
+            is a disk space analyzer
+          </para>
+          <indexterm zone="ncdu ncdu-bin">
+            <primary sortas="b-ncdu">ncdu</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+
+    </variablelist>
+
+  </sect2>  
+
+</sect1>

--- a/general/prog/prog.xml
+++ b/general/prog/prog.xml
@@ -24,6 +24,7 @@
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="socat.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="unlambda.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="xtrace.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="wev.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="java-header.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="java.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ojdk-conf.xml"/>

--- a/general/prog/prog.xml
+++ b/general/prog/prog.xml
@@ -23,6 +23,7 @@
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="strace.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="socat.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="unlambda.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="xtrace.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="java-header.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="java.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ojdk-conf.xml"/>

--- a/general/prog/wev.xml
+++ b/general/prog/wev.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sect1 PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+   "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+  <!ENTITY % general-entities SYSTEM "../../general.ent">
+  %general-entities;
+
+  <!ENTITY wev-download-http "https://git.sr.ht/~sircmpwn/wev/archive/&wev-version;.tar.gz">
+]>
+
+<sect1 id="wev" xreflabel="wev-&wev-version;">
+  <?dbhtml filename="wev.html"?>
+
+  <title>wev-&wev-version;</title>
+
+  <indexterm zone="wev">
+    <primary sortas="a-wev">wev</primary>
+  </indexterm>
+
+  <sect2 role="package">
+    <title>Introduction to wev</title>
+
+    <para>
+      The wev package contains a utility to show Wayland events.
+    </para>
+
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          Download (HTTP): <ulink url="&wev-download-http;"/>
+        </para>
+      </listitem>
+    </itemizedlist>
+
+    <bridgehead renderas="sect3">wev Dependencies</bridgehead>
+
+    <bridgehead renderas="sect4">Required</bridgehead>
+    <para role="required">
+      <ulink url="&blfs-svn;/general/libxkbcommon.html">libxkbcommon</ulink>,
+      <xref linkend="scdoc"/>,
+      <ulink url="&blfs-svn;/general/wayland.html">Wayland</ulink>, and
+      <ulink url="&blfs-svn;/general/wayland-protocols.html">Wayland-Protocols</ulink>
+    </para>
+
+  </sect2>
+
+  <sect2 role="installation">
+    <title>Installation of wev</title>
+
+    <para>
+      Install wev by executing the following commands:
+    </para>
+
+<screen><userinput>make</userinput></screen>
+
+    <para>
+      Now as the &root; user:
+    </para>
+
+<screen role="root"><userinput>make PREFIX=/usr install</userinput></screen>
+
+  </sect2>
+
+  <sect2 role="content">
+    <title>Contents</title>
+
+    <segmentedlist>
+      <segtitle>Installed Programs</segtitle>
+      <segtitle>Installed Libraries</segtitle>
+      <segtitle>Installed Directories</segtitle>
+
+      <seglistitem>
+        <seg>
+          wev
+        </seg>
+        <seg>
+          None 
+        </seg>
+        <seg>
+          None
+        </seg>
+      </seglistitem>
+    </segmentedlist>
+
+    <variablelist>
+      <bridgehead renderas="sect3">Short Descriptions</bridgehead>
+      <?dbfo list-presentation="list"?>
+      <?dbhtml list-presentation="table"?>
+
+      <varlistentry id="wev-bin">
+        <term><command>wev</command></term>
+        <listitem>
+          <para>
+            is a Wayland event tracker
+          </para>
+          <indexterm zone="wev wev-bin">
+            <primary sortas="b-wev-bin">wev</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+
+    </variablelist>
+
+  </sect2>
+
+</sect1>

--- a/general/prog/xtrace.xml
+++ b/general/prog/xtrace.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sect1 PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+   "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+  <!ENTITY % general-entities SYSTEM "../../general.ent">
+  %general-entities;
+
+  <!ENTITY xtrace-download-http "https://github.com/yuq/xtrace/archive/&xtrace-version;.tar.gz">
+]>
+
+<sect1 id="xtrace" xreflabel="xtrace-&xtrace-minor-version;">
+  <?dbhtml filename="xtrace.html"?>
+
+
+  <title>xtrace-&xtrace-minor-version;</title>
+
+  <indexterm zone="xtrace">
+    <primary sortas="a-xtrace">xtrace</primary>
+  </indexterm>
+
+  <sect2 role="package">
+    <title>Introduction to xtrace</title>
+
+    <para>
+      The xtrace package provides a utility to track X11 messages being
+      exchanged between a client and an X server.
+    </para>
+
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          Download (HTTP): <ulink url="&xtrace-download-http;"/>
+        </para>
+      </listitem>
+    </itemizedlist>
+
+  <!-- As far as I can see, nope, this actually does not depend on Xorg libs.
+       There's nothing about it in configure.ac except a couple commented-out
+       lines, and I can't find any references to dlopen(), libX11 or any other
+       methods of dynamically loading libraries I know of outside of a single
+       file that doesn't get compiled in. -seal331 -->
+
+  </sect2>
+
+  <sect2 role="installation">
+    <title>Installation of xtrace</title>
+
+    <para>
+      Compile xtrace by running the following commands:
+    </para>
+
+<screen><userinput>autoreconf -fiv &amp;&amp;
+./configure --prefix=/usr &amp;&amp;
+make</userinput></screen>
+
+    <para>
+      In order to avoid conflicts with the xtrace binary installed by Glibc,
+      execute the following commands as the &root; user to install the package:
+    </para>
+
+<screen role="root"><userinput>DESTDIR=$PWD/DESTDIR make install &amp;&amp;
+mv -v DESTDIR/usr/bin/xtrace{,_x11} &amp;&amp;
+mv -v DESTDIR/usr/share/man/man1/xtrace{,_x11}.1 &amp;&amp;
+cp -vR DESTDIR/usr/* /usr</userinput></screen>
+
+  </sect2>
+  
+  <sect2 role="content">
+    <title>Contents</title>
+
+    <segmentedlist>
+      <segtitle>Installed Programs</segtitle>
+      <segtitle>Installed Libraries</segtitle>
+      <segtitle>Installed Directories</segtitle>
+
+      <seglistitem>
+        <seg>
+          xtrace_x11
+        </seg>
+        <seg>
+          None
+        </seg>
+        <seg>
+          /usr/share/xtrace
+        </seg>
+      </seglistitem>
+    </segmentedlist>
+
+    <variablelist>
+      <bridgehead renderas="sect3">Short Descriptions</bridgehead>
+      <?dbfo list-presentation="list"?>
+      <?dbhtml list-presentation="table"?>
+
+      <varlistentry id="xtrace-prog">
+        <term><command>xtrace</command></term>
+        <listitem>
+         <para>
+           traces X11 messages, most often used for debugging
+         </para>
+          <indexterm zone="xtrace xtrace-prog">
+            <primary sortas="b-xtrace">xtrace</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+
+    </variablelist>
+
+  </sect2>
+
+</sect1>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -44,6 +44,10 @@
       <para>August 11th, 2025</para>
       <itemizedlist>
         <listitem>
+          <para>[seal331] - ncdu: Added. Fixes
+          <ulink url="&slfs-issues;/246">#246</ulink>.</para>
+        </listitem>
+        <listitem>
           <para>[seal331] - xtrace: Added.</para>
         </listitem>
       </itemizedlist>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -41,6 +41,15 @@
     -->
 
     <listitem>
+      <para>August 11th, 2025</para>
+      <itemizedlist>
+        <listitem>
+          <para>[seal331] - xtrace: Added.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>August 9th, 2025</para>
       <itemizedlist>
         <listitem>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -44,6 +44,10 @@
       <para>August 11th, 2025</para>
       <itemizedlist>
         <listitem>
+          <para>[seal331] - wev: Added. Fixes
+          <ulink url="&slfs-issues;/258">#258</ulink>.</para>
+        </listitem>
+        <listitem>
           <para>[seal331] - ncdu: Added. Fixes
           <ulink url="&slfs-issues;/246">#246</ulink>.</para>
         </listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -68,6 +68,7 @@ version, so keep this at that. -->
 <!ENTITY minicom-version                     "2.10">
 <!ENTITY gkermit-version                     "2.01">
 <!ENTITY gkermit-tarball-version             "gku201">
+<!ENTITY ncdu-version                        "1.22">
 <!ENTITY ncompress-version                   "5.0">
 <!ENTITY neofetch-version                    "7.1.0">
 <!ENTITY fastfetch-version                   "2.48.1">

--- a/packages.ent
+++ b/packages.ent
@@ -110,6 +110,8 @@ version, so keep this at that. -->
 <!ENTITY strace-version                      "6.15">
 <!ENTITY socat-version                       "1.8.0.3">
 <!ENTITY unlambda-version                    "2.0.0">
+<!ENTITY xtrace-minor-version                "fd1e5a">
+<!ENTITY xtrace-version                      "fd1e5a94628acc6277904c547992825aefa119c6">
 <!-- JAVA -->
 <!ENTITY java-major-version                  "17">
 <!ENTITY java-version                        "&java-major-version;.0.16">

--- a/packages.ent
+++ b/packages.ent
@@ -92,18 +92,18 @@ version, so keep this at that. -->
 <!ENTITY gcc-version                         "15.1.0">
 <!ENTITY gnat-binary-version                 "&gcc-version;-2">
 <!-- START PYTHON -->
-<!ENTITY python3-major                "3">
-<!ENTITY python3-minor                "13">
-<!ENTITY python3-patch                "4">
-<!ENTITY python3-majorver             "&python3-major;.&python3-minor;">
-<!ENTITY python3-version              "&python3-majorver;.&python3-patch;">
-<!ENTITY python3-lib-suffix           "cpython-&python3-major;&python3-minor;-&lt;arch&gt;-linux-gnu">
-<!ENTITY python3-site                 "/usr/lib/python&python3-majorver;/site-packages">
+<!ENTITY python3-major                       "3">
+<!ENTITY python3-minor                       "13">
+<!ENTITY python3-patch                       "4">
+<!ENTITY python3-majorver                    "&python3-major;.&python3-minor;">
+<!ENTITY python3-version                     "&python3-majorver;.&python3-patch;">
+<!ENTITY python3-lib-suffix                  "cpython-&python3-major;&python3-minor;-&lt;arch&gt;-linux-gnu">
+<!ENTITY python3-site                        "/usr/lib/python&python3-majorver;/site-packages">
 <!-- Python Dependencies -->
 <!ENTITY structlog-version                   "25.4.0">
 <!ENTITY platformdirs-version                "4.3.8">
 <!ENTITY pycurl-version                      "7.45.6">
-<!ENTITY toml-version                      "0.10.2">
+<!ENTITY toml-version                        "0.10.2">
 <!ENTITY tornado-version                     "6.5.2">
 <!-- Python Modules -->
 <!ENTITY nvchecker-version                   "2.18">
@@ -113,6 +113,7 @@ version, so keep this at that. -->
 <!ENTITY unlambda-version                    "2.0.0">
 <!ENTITY xtrace-minor-version                "fd1e5a">
 <!ENTITY xtrace-version                      "fd1e5a94628acc6277904c547992825aefa119c6">
+<!ENTITY wev-version                         "1.1.0">
 <!-- JAVA -->
 <!ENTITY java-major-version                  "17">
 <!ENTITY java-version                        "&java-major-version;.0.16">


### PR DESCRIPTION
This PR adds the following packages:

- ncdu (currently the LTS C version, Zig version to be added if/when Zig support gets added into SLFS, fixes #246)
- wev (fixes #258)
- xtrace (was briefly mentioned in #258)

I also slightly modified some padding in packages.ent so all entities have the same indentation again (some Python stuff had the wrong indentation previously)

Open to any changes.