### PR TITLE
Add libvpl, Intel Media SDK, Intel OneVPL, and libvpl-tools to allow video acceleration in OBS Studio

### DIFF
--- a/general/graphlib/graphlib.xml
+++ b/general/graphlib/graphlib.xml
@@ -18,6 +18,7 @@
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="fcft.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="glu.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="intel-mediasdk.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="intel-onevpl.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="libdecor.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="libliftoff.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="libspng.xml"/>

--- a/general/graphlib/graphlib.xml
+++ b/general/graphlib/graphlib.xml
@@ -17,6 +17,7 @@
 
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="fcft.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="glu.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="intel-mediasdk.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="libdecor.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="libliftoff.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="libspng.xml"/>

--- a/general/graphlib/graphlib.xml
+++ b/general/graphlib/graphlib.xml
@@ -22,6 +22,7 @@
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="libdecor.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="libliftoff.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="libspng.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="libvpl.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="nv-codec-headers.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="xdg-desktop-portal-hyprland.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="xdg-desktop-portal-wlr.xml"/>

--- a/general/graphlib/intel-mediasdk.xml
+++ b/general/graphlib/intel-mediasdk.xml
@@ -105,10 +105,6 @@ make</userinput></screen>
   <sect2 role="commands">
     <title>Command Explanations</title>
 
-    <note><para>
-      Invoke <userinput>cmake -L ../CMakeLists.txt</userinput> for a full list of options.
-    </para></note>
-
     <para>
       <parameter>-D BUILD_ALL=ON</parameter>: This parameter builds support for
       all Intel iGPUs included with the Broadwell series through the Tiger Lake
@@ -147,6 +143,9 @@ make</userinput></screen>
       <parameter>-D MFX_APPS_DIR=/usr/lib/mfx</parameter>: This parameter
       places the samples that were compiled into /usr/lib/mfx.
     </para>
+
+    &options-cmake;
+
   </sect2>
 
   <sect2 role="content">

--- a/general/graphlib/intel-mediasdk.xml
+++ b/general/graphlib/intel-mediasdk.xml
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sect1 PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+   "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+  <!ENTITY % general-entities SYSTEM "../../general.ent">
+  %general-entities;
+
+  <!ENTITY intel-mediasdk-download-http "https://github.com/Intel-Media-SDK/MediaSDK/archive/refs/tags/intel-mediasdk-&intel-mediasdk-version;.tar.gz">
+]>
+
+<sect1 id="intel-mediasdk" xreflabel="Intel-MediaSDK-&intel-mediasdk-version;">
+  <?dbhtml filename="intel-mediasdk.html"?>
+
+  <title>Intel-MediaSDK-&intel-mediasdk-version;</title>
+
+  <indexterm zone="intel-mediasdk">
+    <primary sortas="a-intel-mediasdk">Intel-MediaSDK</primary>
+  </indexterm>
+
+  <sect2 role="package">
+    <title>Introduction to Intel-MediaSDK</title>
+
+    <para>
+      The Intel-MediaSDK package contains a set of libraries that provide
+      support for video acceleration for encoding and decoding tasks on legacy
+      Intel GPUs. This includes Intel iGPUs from the 5th Generation CPUs
+      (Broadwell) through the 11th Generation CPUs (Tiger Lake). This package
+      also provides a dispatcher library that is needed by applications like
+      ffmpeg to properly enable support for GPU acceleration with Intel GPUs.
+    </para>
+
+    &long-build-time;
+
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          Download (HTTP): <ulink url="&intel-mediasdk-download-http;"/>
+        </para>
+      </listitem>
+    </itemizedlist>
+
+    <bridgehead renderas="sect3">Intel-MediaSDK Dependencies</bridgehead>
+
+    <bridgehead renderas="sect4">Required</bridgehead>
+    <para role="required">
+      <ulink url="&blfs-svn;/general/cmake.html">CMake</ulink>,
+      <ulink url="&blfs-svn;/general/gmmlib.html">gmmlib</ulink>,
+      <ulink url="&blfs-svn;/multimedia/intel-media-driver.html">intel-media-driver</ulink>,
+      <ulink url="&blfs-svn;/x/libdrm.html">libdrm</ulink>,
+      <ulink url="&blfs-svn;/multimedia/libva.html">libva</ulink>,
+      <ulink url="&blfs-svn;/x/libxcb.html">libxcb</ulink>,
+      <ulink url="&blfs-svn;/general/wayland.html">Wayland</ulink>, and
+      <ulink url="&blfs-svn;/x/x7lib.html">Xorg Libraries</ulink>
+    </para>
+
+    <para>
+      This package extracts to MediaSDK-intel-mediasdk-&intel-mediasdk-version;.
+    </para>
+  </sect2>
+
+  <sect2 role="installation">
+    <title>Installation of Intel-MediaSDK</title>
+
+    <para>
+      First, fix two build failures caused by GCC-15:
+    </para>
+    
+<screen><userinput remap="pre">sed -i '/&lt;string.h&gt;/a #include &lt;cstdint&gt;' api/mfx_dispatch/linux/mfxparser.cpp &amp;&amp;
+sed -i '/&lt;math.h&gt;/a #include &lt;cstdint&gt;'   samples/sample_vpp/src/sample_vpp_frc_adv.cpp</userinput></screen>
+        
+    <para>
+      Install Intel-MediaSDK by running the following
+      commands:
+    </para>
+
+<screen><userinput>mkdir build &amp;&amp;
+cd    build &amp;&amp;
+
+cmake -D CMAKE_INSTALL_PREFIX=/usr        \
+      -D CMAKE_BUILD_TYPE=Release         \
+      -D CMAKE_SKIP_INSTALL_RPATH=ON      \
+      -D CMAKE_POLICY_VERSION_MINIMUM=3.5 \
+      -D BUILD_ALL=ON                     \
+      -D BUILD_TOOLS=ON                   \
+      -D ENABLE_ITT=OFF                   \
+      -D ENABLE_OPENCL=OFF                \
+      -D ENABLE_WAYLAND=ON                \
+      -D ENABLE_X11_DRI3=ON               \
+      -D MFX_APPS_DIR=/usr/lib/mfx        \
+      -W no-dev ..                        &amp;&amp;
+make</userinput></screen>
+
+    <para>
+      To test the results, issue: <command>ctest</command>.
+    </para>
+
+    <para>
+      Now, as the &root; user:
+    </para>
+
+<screen role="root"><userinput>make install</userinput></screen>
+
+  </sect2>
+
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    <note><para>
+      Invoke <userinput>cmake -L ../CMakeLists.txt</userinput> for a full list of options.
+    </para></note>
+
+    <para>
+      <parameter>-D BUILD_ALL=ON</parameter>: This parameter builds support for
+      all Intel iGPUs included with the Broadwell series through the Tiger Lake
+      series, as well as support for all codecs.
+    </para>
+
+    <para>
+      <parameter>-D BUILD_TOOLS=ON</parameter>: This parameter builds all of
+      the tools needed for utilizing the GPUs that this package supports.
+    </para>
+    
+    <para>
+      <parameter>-D ENABLE_ITT=OFF</parameter>: This parameter disables support
+      for ITT (VTune) instrumentation support. This support requires several
+      packages which are no longer available.
+    </para>
+    
+    <para>
+      <parameter>-D ENABLE_OPENCL=OFF</parameter>: This parameter disables
+      support for OpenCL acceleration via the Intel Media SDK. This has been
+      disabled because the packages needed have been discontinued for years and
+      are no longer available.
+    </para>
+    
+    <para>
+      <parameter>-D ENABLE_WAYLAND=ON</parameter>: This parameter enables
+      support for GPU acceleration for supported Intel GPUs when using Wayland.
+    </para>
+    
+    <para>
+      <parameter>-D ENABLE_X11_DRI3=ON</parameter>: This parameter enables
+      support for GPU acceleration through DRI3 for supported Intel GPUs.
+    </para>
+    
+    <para>
+      <parameter>-D MFX_APPS_DIR=/usr/lib/mfx</parameter>: This parameter
+      places the samples that were compiled into /usr/lib/mfx.
+    </para>
+  </sect2>
+
+  <sect2 role="content">
+    <title>Contents</title>
+
+    <segmentedlist>
+      <segtitle>Installed Programs</segtitle>
+      <segtitle>Installed Libraries</segtitle>
+      <segtitle>Installed Directories</segtitle>
+
+
+      <seglistitem>
+        <seg>
+          asg-hevc,
+          hevc_fei_extractor, and
+          mfx-tracer-config
+        </seg>
+        <seg>
+          libmfx,
+          libmfxhw64,
+          and libmfx-tracer
+        </seg>
+        <seg>
+          /usr/{include,lib,share}/mfx
+        </seg>
+      </seglistitem>
+    </segmentedlist>
+
+    <variablelist>
+      <bridgehead renderas="sect3">Short Descriptions</bridgehead>
+      <?dbfo list-presentation="list"?>
+      <?dbhtml list-presentation="table"?>
+
+      <varlistentry id="asg-hevc">
+        <term><command>asg-hevc</command></term>
+        <listitem>
+          <para>
+            encodes files using the HEVC codec while using this package for
+            GPU acceleration
+          </para>
+          <indexterm zone="intel-mediasdk asg-hevc">
+            <primary sortas="b-asg-hevc">asg-hevc</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry id="hevc_fei_extractor">
+        <term><command>hevc_fei_extractor</command></term>
+        <listitem>
+          <para>
+            dumps fei-specific information from HEVC bit streams
+          </para>
+          <indexterm zone="intel-mediasdk hevc_fei_extractor">
+            <primary sortas="b-hevc_fei_extractor">hevc_fei_extractor</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry id="mfx-tracer-config">
+        <term><command>mfx-tracer-config</command></term>
+        <listitem>
+          <para>
+            generates configuration for the MFX tracer
+          </para>
+          <indexterm zone="intel-mediasdk mfx-tracer-config">
+            <primary sortas="b-mfx-tracer-config">mfx-tracer-config</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry id="libmfx">
+        <term><filename class="libraryfile">libmfx</filename></term>
+        <listitem>
+          <para>
+            provides a dispatcher for the Intel MediaSDK
+          </para>
+          <indexterm zone="intel-mediasdk libmfx">
+            <primary sortas="c-libmfx">libmfx</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+      
+      <varlistentry id="libmfxhw64">
+        <term><filename class="libraryfile">libmfxhw64</filename></term>
+        <listitem>
+          <para>
+            provides a dispatcher for libvpl to use when a newer GPU is in use
+          </para>
+          <indexterm zone="intel-mediasdk libmfxhw64">
+            <primary sortas="c-libmfxhw64">libmfxhw64</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+      
+      <varlistentry id="libmfx-tracer">
+        <term><filename class="libraryfile">libmfx-tracer</filename></term>
+        <listitem>
+          <para>
+            provides functions that trace API calls within libmfx
+          </para>
+          <indexterm zone="intel-mediasdk libmfx-tracer">
+            <primary sortas="c-libmfx-tracer">libmfx-tracer</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </sect2>
+</sect1>

--- a/general/graphlib/intel-mediasdk.xml
+++ b/general/graphlib/intel-mediasdk.xml
@@ -22,10 +22,11 @@
     <para>
       The Intel-MediaSDK package contains a set of libraries that provide
       support for video acceleration for encoding and decoding tasks on legacy
-      Intel GPUs. This includes Intel iGPUs from the 5th Generation CPUs
-      (Broadwell) through the 11th Generation CPUs (Tiger Lake). This package
-      also provides a dispatcher library that is needed by applications like
-      ffmpeg to properly enable support for GPU acceleration with Intel GPUs.
+      Intel GPUs. This includes Intel iGPUs from the 5th Generation Core CPUs
+      (Broadwell) through the 11th Generation Core CPUs (Tiger Lake). This
+      package also provides a dispatcher library that is needed by applications
+      such as ffmpeg to properly enable support for GPU acceleration with Intel
+      GPUs.
     </para>
 
     &long-build-time;
@@ -220,7 +221,7 @@ make</userinput></screen>
         <term><filename class="libraryfile">libmfx</filename></term>
         <listitem>
           <para>
-            provides a dispatcher for the Intel MediaSDK
+            provides a dispatcher for the Broadwell through Tiger Lake iGPUs
           </para>
           <indexterm zone="intel-mediasdk libmfx">
             <primary sortas="c-libmfx">libmfx</primary>
@@ -232,7 +233,8 @@ make</userinput></screen>
         <term><filename class="libraryfile">libmfxhw64</filename></term>
         <listitem>
           <para>
-            provides a dispatcher for libvpl to use when a newer GPU is in use
+            provides a dispatcher for libvpl to use when an unsupported GPU is
+            in use, forwarding the request to the newer runtime
           </para>
           <indexterm zone="intel-mediasdk libmfxhw64">
             <primary sortas="c-libmfxhw64">libmfxhw64</primary>

--- a/general/graphlib/intel-mediasdk.xml
+++ b/general/graphlib/intel-mediasdk.xml
@@ -48,9 +48,13 @@
       <ulink url="&blfs-svn;/multimedia/intel-media-driver.html">intel-media-driver</ulink>,
       <ulink url="&blfs-svn;/x/libdrm.html">libdrm</ulink>,
       <ulink url="&blfs-svn;/multimedia/libva.html">libva</ulink>,
-      <ulink url="&blfs-svn;/x/libxcb.html">libxcb</ulink>,
-      <ulink url="&blfs-svn;/general/wayland.html">Wayland</ulink>, and
+      <ulink url="&blfs-svn;/x/libxcb.html">libxcb</ulink>, and
       <ulink url="&blfs-svn;/x/x7lib.html">Xorg Libraries</ulink>
+    </para>
+
+    <bridgehead renderas="sect4">Recommended</bridgehead>
+    <para role="recommended">
+      <ulink url="&blfs-svn;/general/wayland.html">Wayland</ulink>
     </para>
 
     <para>

--- a/general/graphlib/intel-onevpl.xml
+++ b/general/graphlib/intel-onevpl.xml
@@ -85,10 +85,6 @@ make</userinput></screen>
   <sect2 role="commands">
     <title>Command Explanations</title>
 
-    <note><para>
-      Invoke <userinput>cmake -L ../CMakeLists.txt</userinput> for a full list of options.
-    </para></note>
-
     <para>
       <parameter>-D BUILD_TESTS=OFF</parameter>: This parameter disables the
       tests as they are broken and require several external dependencies.
@@ -98,6 +94,8 @@ make</userinput></screen>
       <parameter>-D MFX_ENABLE_AENC=ON</parameter>: This parameter enables the
       AENC extension.
     </para>
+
+    &options-cmake;
 
   </sect2>
 

--- a/general/graphlib/intel-onevpl.xml
+++ b/general/graphlib/intel-onevpl.xml
@@ -36,15 +36,15 @@
       </listitem>
     </itemizedlist>
 
-    <bridgehead renderas="sect3">Intel-MediaSDK Dependencies</bridgehead>
+    <bridgehead renderas="sect3">intel-onevpl Dependencies</bridgehead>
 
     <bridgehead renderas="sect4">Required</bridgehead>
     <para role="required">
       <ulink url="&blfs-svn;/general/cmake.html">CMake</ulink>,
       <ulink url="&blfs-svn;/general/gmmlib.html">gmmlib</ulink>,
       <ulink url="&blfs-svn;/multimedia/intel-media-driver.html">intel-media-driver</ulink>,
-      <ulink url="&blfs-svn;/x/libdrm.html">libdrm</ulink>,
-      <ulink url="&blfs-svn;/multimedia/libva.html">libva</ulink>,
+      <ulink url="&blfs-svn;/x/libdrm.html">libdrm</ulink>, and
+      <ulink url="&blfs-svn;/multimedia/libva.html">libva</ulink>
     </para>
 
     <para>

--- a/general/graphlib/intel-onevpl.xml
+++ b/general/graphlib/intel-onevpl.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sect1 PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+   "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+  <!ENTITY % general-entities SYSTEM "../../general.ent">
+  %general-entities;
+
+  <!ENTITY intel-onevpl-download-http "https://github.com/intel/vpl-gpu-rt/archive/refs/tags/intel-onevpl-&intel-onevpl-version;.tar.gz">
+]>
+
+<sect1 id="intel-onevpl" xreflabel="intel-onevpl-&intel-onevpl-version;">
+  <?dbhtml filename="intel-onevpl.html"?>
+
+  <title>intel-onevpl-&intel-mediasdk-version;</title>
+
+  <indexterm zone="intel-onevpl">
+    <primary sortas="a-intel-onevpl">intel-onevpl</primary>
+  </indexterm>
+
+  <sect2 role="package">
+    <title>Introduction to intel-onevpl</title>
+
+    <para>
+      The intel-onevpl package contains a set of libraries that provide
+      support for video acceleration for encoding and decoding tasks on modern
+      Intel GPUs. This includes every GPU produced from the Tiger Lake (11th
+      Generation) CPUs and later, including the Arc and Iris Xe GPUs.
+    </para>
+
+    &long-build-time;
+
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          Download (HTTP): <ulink url="&intel-onevpl-download-http;"/>
+        </para>
+      </listitem>
+    </itemizedlist>
+
+    <bridgehead renderas="sect3">Intel-MediaSDK Dependencies</bridgehead>
+
+    <bridgehead renderas="sect4">Required</bridgehead>
+    <para role="required">
+      <ulink url="&blfs-svn;/general/cmake.html">CMake</ulink>,
+      <ulink url="&blfs-svn;/general/gmmlib.html">gmmlib</ulink>,
+      <ulink url="&blfs-svn;/multimedia/intel-media-driver.html">intel-media-driver</ulink>,
+      <ulink url="&blfs-svn;/x/libdrm.html">libdrm</ulink>,
+      <ulink url="&blfs-svn;/multimedia/libva.html">libva</ulink>,
+    </para>
+
+    <para>
+      This package extracts to vpl-gpu-rt-intel-onevpl-&intel-onevpl-version;.
+    </para>
+  </sect2>
+
+  <sect2 role="installation">
+    <title>Installation of intel-onevpl</title>
+        
+    <para>
+      Install intel-onevpl by running the following commands:
+    </para>
+
+<screen><userinput>mkdir build &amp;&amp;
+cd    build &amp;&amp;
+
+cmake -D CMAKE_INSTALL_PREFIX=/usr   \
+      -D CMAKE_BUILD_TYPE=Release    \
+      -D CMAKE_SKIP_INSTALL_RPATH=ON \
+      -D BUILD_TESTS=OFF             \
+      -D MFX_ENABLE_AENC=ON          \
+      -W no-dev ..                   &amp;&amp;
+make</userinput></screen>
+
+    <para>
+      This package does not come with a working test suite.
+    </para>
+
+    <para>
+      Now, as the &root; user:
+    </para>
+
+<screen role="root"><userinput>make install</userinput></screen>
+
+  </sect2>
+
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    <note><para>
+      Invoke <userinput>cmake -L ../CMakeLists.txt</userinput> for a full list of options.
+    </para></note>
+
+    <para>
+      <parameter>-D BUILD_TESTS=OFF</parameter>: This parameter disables the
+      tests as they are broken and require several external dependencies.
+    </para>
+
+    <para>
+      <parameter>-D MFX_ENABLE_AENC=ON</parameter>: This parameter enables the
+      AENC extension.
+    </para>
+
+  </sect2>
+
+  <sect2 role="content">
+    <title>Contents</title>
+
+    <segmentedlist>
+      <segtitle>Installed Programs</segtitle>
+      <segtitle>Installed Libraries</segtitle>
+      <segtitle>Installed Directories</segtitle>
+
+
+      <seglistitem>
+        <seg>
+          None
+        </seg>
+        <seg>
+          libmfx-gen
+        </seg>
+        <seg>
+          /usr/lib/libmfx-gen
+        </seg>
+      </seglistitem>
+    </segmentedlist>
+
+    <variablelist>
+      <bridgehead renderas="sect3">Short Descriptions</bridgehead>
+      <?dbfo list-presentation="list"?>
+      <?dbhtml list-presentation="table"?>
+
+      <varlistentry id="libmfx-gen">
+        <term><filename class="libraryfile">libmfx-gen</filename></term>
+        <listitem>
+          <para>
+            provides support for GPU accelerated video encoding and decoding
+            on Intel GPUs from the Tiger Lake generation and higher
+          </para>
+          <indexterm zone="intel-onevpl libmfx-gen">
+            <primary sortas="c-libmfx-gen">libmfx-gen</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </sect2>
+</sect1>

--- a/general/graphlib/intel-onevpl.xml
+++ b/general/graphlib/intel-onevpl.xml
@@ -22,8 +22,8 @@
     <para>
       The intel-onevpl package contains a set of libraries that provide
       support for video acceleration for encoding and decoding tasks on modern
-      Intel GPUs. This includes every GPU produced from the Tiger Lake (11th
-      Generation) CPUs and later, including the Arc and Iris Xe GPUs.
+      Intel GPUs. This includes every GPU built into the Tiger Lake (11th
+      Generation) CPUs and later, as well as the Arc and Iris Xe GPUs.
     </para>
 
     &long-build-time;
@@ -133,7 +133,7 @@ make</userinput></screen>
         <listitem>
           <para>
             provides support for GPU accelerated video encoding and decoding
-            on Intel GPUs from the Tiger Lake generation and higher
+            on Intel GPUs from the Tiger Lake CPU generation and later
           </para>
           <indexterm zone="intel-onevpl libmfx-gen">
             <primary sortas="c-libmfx-gen">libmfx-gen</primary>

--- a/general/graphlib/libvpl.xml
+++ b/general/graphlib/libvpl.xml
@@ -89,6 +89,13 @@ make</userinput></screen>
 
   </sect2>
 
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    &options-cmake;
+
+  </sect2>
+
   <sect2 role="content">
     <title>Contents</title>
 

--- a/general/graphlib/libvpl.xml
+++ b/general/graphlib/libvpl.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sect1 PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+   "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+  <!ENTITY % general-entities SYSTEM "../../general.ent">
+  %general-entities;
+
+  <!ENTITY libvpl-download-http "https://github.com/intel/libvpl/archive/refs/tags/v&libvpl-version;/libvpl-&libvpl-version;.tar.gz">
+]>
+
+<sect1 id="libvpl" xreflabel="libvpl-&libvpl-version;">
+  <?dbhtml filename="libvpl.html"?>
+
+  <title>libvpl-&libvpl-version;</title>
+
+  <indexterm zone="libvpl">
+    <primary sortas="a-libvpl">libvpl</primary>
+  </indexterm>
+
+  <sect2 role="package">
+    <title>Introduction to libvpl</title>
+
+    <para>
+      The libvpl package contains a set of libraries that provide the API,
+      dispatcher, and examples for the Intel Video Processing API. libvpl calls
+      upon the Intel MediaSDK and the Intel OneVPL runtimes depending on which
+      GPU is in use.
+    </para>
+
+    &long-build-time;
+
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          Download (HTTP): <ulink url="&libvpl-download-http;"/>
+        </para>
+      </listitem>
+    </itemizedlist>
+
+    <bridgehead renderas="sect3">libvpl Dependencies</bridgehead>
+
+    <bridgehead renderas="sect4">Required</bridgehead>
+    <para role="required">
+      <ulink url="&blfs-svn;/general/cmake.html">CMake</ulink>,
+      <ulink url="&blfs-svn;/general/gmmlib.html">gmmlib</ulink>,
+      <ulink url="&blfs-svn;/multimedia/intel-media-driver.html">intel-media-driver</ulink>,
+      <ulink url="&blfs-svn;/x/libdrm.html">libdrm</ulink>, and
+      <ulink url="&blfs-svn;/multimedia/libva.html">libva</ulink>
+    </para>
+
+    <bridgehead renderas="sect4">Required at runtime</bridgehead>
+    <para role="required">
+      <xref role="runtime" linkend="intel-mediasdk"/> (for GPUs
+      built into the Broadwell (5th Generation) through Tiger Lake (11th
+      Generation) CPUs), and
+      <xref role="runtime" linkend="intel-onevpl"/> (for GPUs built
+      into the Tiger Lake (11th Generation) and later CPUs as well as the Iris
+      Xe and Arc series of GPUs)
+    </para>
+
+  </sect2>
+
+  <sect2 role="installation">
+    <title>Installation of libvpl</title>
+        
+    <para>
+      Install libvpl by running the following commands:
+    </para>
+
+<screen><userinput>mkdir build &amp;&amp;
+cd    build &amp;&amp;
+
+cmake -D CMAKE_INSTALL_PREFIX=/usr     \
+      -D CMAKE_INSTALL_SYSCONFDIR=/etc \
+      -D CMAKE_BUILD_TYPE=Release      \
+      -D CMAKE_SKIP_INSTALL_RPATH=ON   \
+      -D BUILD_EXAMPLES=OFF            \
+      -D BUILD_TESTS=ON                \
+      -W no-dev ..                     &amp;&amp;
+make</userinput></screen>
+
+    <para>
+      To test the results, issue: <command>ctest</command>.
+    </para>
+
+    <para>
+      Now, as the &root; user:
+    </para>
+
+<screen role="root"><userinput>make install</userinput></screen>
+
+  </sect2>
+
+  <sect2 role="content">
+    <title>Contents</title>
+
+    <segmentedlist>
+      <segtitle>Installed Programs</segtitle>
+      <segtitle>Installed Libraries</segtitle>
+      <segtitle>Installed Directories</segtitle>
+
+      <seglistitem>
+        <seg>
+          None
+        </seg>
+        <seg>
+          libvpl
+        </seg>
+        <seg>
+          /etc/vpl and
+          /usr/{include,lib/cmake,share}/vpl
+        </seg>
+      </seglistitem>
+    </segmentedlist>
+
+    <variablelist>
+      <bridgehead renderas="sect3">Short Descriptions</bridgehead>
+      <?dbfo list-presentation="list"?>
+      <?dbhtml list-presentation="table"?>
+
+      <varlistentry id="libvpl-lib">
+        <term><filename class="libraryfile">libvpl</filename></term>
+        <listitem>
+          <para>
+            provides the Intel Video Processing API, including a dispatcher to
+            call upon the right runtime depending on which GPU is in use
+          </para>
+          <indexterm zone="libvpl libvpl-lib">
+            <primary sortas="c-libvpl">libvpl</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </sect2>
+</sect1>

--- a/general/graphlib/libvpl.xml
+++ b/general/graphlib/libvpl.xml
@@ -50,11 +50,10 @@
     <bridgehead renderas="sect4">Required at runtime</bridgehead>
     <para role="required">
       <xref role="runtime" linkend="intel-mediasdk"/> (for GPUs
-      built into the Broadwell (5th Generation) through Tiger Lake (11th
-      Generation) CPUs), and
+      built into the Broadwell through Tiger Lake CPUs), or
       <xref role="runtime" linkend="intel-onevpl"/> (for GPUs built
-      into the Tiger Lake (11th Generation) and later CPUs as well as the Iris
-      Xe and Arc series of GPUs)
+      into the Tiger Lake and later CPUs as well as the Iris Xe and Arc series
+      of GPUs)
     </para>
 
   </sect2>

--- a/graph/app/app.xml
+++ b/graph/app/app.xml
@@ -15,6 +15,7 @@
     existing category.
   </para>
 
+   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="libvpl-tools.xml"/>
    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="mesa-demos.xml"/>
    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="obs-studio.xml"/>
    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="wbg.xml"/>

--- a/graph/app/libvpl-tools.xml
+++ b/graph/app/libvpl-tools.xml
@@ -1,0 +1,255 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sect1 PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+   "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+  <!ENTITY % general-entities SYSTEM "../../general.ent">
+  %general-entities;
+
+  <!ENTITY libvpl-tools-download-http "https://github.com/intel/libvpl-tools/archive/v&libvpl-tools-version;/libvpl-tools-&libvpl-tools-version;.tar.gz">
+]>
+
+<sect1 id="libvpl-tools" xreflabel="libvpl-tools-&libvpl-tools-version;">
+  <?dbhtml filename="libvpl-tools.html"?>
+
+  <title>libvpl-tools-&libvpl-tools-version;</title>
+
+  <indexterm zone="libvpl-tools">
+    <primary sortas="a-libvpl-tools">libvpl-tools</primary>
+  </indexterm>
+
+  <sect2 role="package">
+    <title>Introduction to libvpl-tools</title>
+
+    <para>
+      The libvpl-tools package provides a set of utilities useful for diagnosing
+      problems with the Intel Video Processing API. In addition, it also provides
+      sample utilties that can be used to test the API.
+    </para>
+
+    &long-build-time;
+
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          Download (HTTP): <ulink url="&libvpl-tools-download-http;"/>
+        </para>
+      </listitem>
+    </itemizedlist>
+
+    <bridgehead renderas="sect3">libvpl-tools Dependencies</bridgehead>
+
+    <bridgehead renderas="sect4">Required</bridgehead>
+    <para role="required">
+      <ulink url="&blfs-svn;/general/cmake.html">CMake</ulink>,
+      <ulink url="&blfs-svn;/general/gmmlib.html">gmmlib</ulink>,
+      <ulink url="&blfs-svn;/multimedia/intel-media-driver.html">intel-media-driver</ulink>,
+      <ulink url="&blfs-svn;/x/libdrm.html">libdrm</ulink>,
+      <ulink url="&blfs-svn;/multimedia/libva.html">libva</ulink>,
+      <xref linkend="libvpl"/>,
+      <ulink url="&blfs-svn;/general/wayland.html">Wayland</ulink>,
+      <ulink url="&blfs-svn;/general/wayland-protocols.html">wayland-protocols</ulink>, and
+      <ulink url="&blfs-svn;/x/x7lib.html">Xorg Libraries</ulink>
+    </para>
+
+  </sect2>
+
+  <sect2 role="installation">
+    <title>Installation of libvpl-tools</title>
+
+    <para>
+      First, fix a build failure caused by GCC-15:
+    </para>
+    
+<screen><userinput remap="pre">sed -i '/sample_vpp_frc_adv.h/a #include &lt;cstdint&gt;' tools/legacy/sample_vpp/src/sample_vpp_frc_adv.cpp</userinput></screen>
+
+    <para>
+      Install libvpl-tools by running the following commands:
+    </para>
+
+<screen><userinput>mkdir build &amp;&amp;
+cd    build &amp;&amp;
+
+cmake -D CMAKE_INSTALL_PREFIX=/usr     \
+      -D CMAKE_BUILD_TYPE=Release      \
+      -D CMAKE_SKIP_INSTALL_RPATH=ON   \
+      -D BUILD_TESTS=ON                \
+      -W no-dev ..                     &amp;&amp;
+make</userinput></screen>
+
+    <para>
+      To test the results, issue: <command>ctest</command>.
+    </para>
+
+    <para>
+      Now, as the &root; user:
+    </para>
+
+<screen role="root"><userinput>make install</userinput></screen>
+
+    <para>
+      Finally, clean up the installed programs by renaming some to more
+      appropriate names as the &root; user:
+    </para>
+
+<screen role="root"><userinput>mv -v /usr/bin/metrics_monitor        /usr/bin/vpl-metrics-monitor         &amp;&amp;
+mv -v /usr/bin/sample_decode          /usr/bin/vpl-sample-decode           &amp;&amp;
+mv -v /usr/bin/sample_encode          /usr/bin/vpl-sample-encode           &amp;&amp;
+mv -v /usr/bin/sample_multi_transcode /usr/bin/vpl-sample-multi_transcode  &amp;&amp;
+mv -v /usr/bin/system_analyzer        /usr/bin/vpl-system-analyzer</userinput></screen>
+
+  </sect2>
+
+  <sect2 role="content">
+    <title>Contents</title>
+
+    <segmentedlist>
+      <segtitle>Installed Programs</segtitle>
+      <segtitle>Installed Libraries</segtitle>
+      <segtitle>Installed Directories</segtitle>
+
+      <seglistitem>
+        <seg>
+          val-surface-sharing,
+          vpl-import-export,
+          vpl-inspect,
+          vpl-metrics-monitor,
+          vpl-sample-decode,
+          vpl-sample-encode,
+          vpl-sample-multi-transcode,
+          vpl-sample-vpp, and
+          vpl-system-analyzer
+        </seg>
+        <seg>
+          None
+        </seg>
+        <seg>
+          /usr/{lib,share}/libvpl-tools
+        </seg>
+      </seglistitem>
+    </segmentedlist>
+
+    <variablelist>
+      <bridgehead renderas="sect3">Short Descriptions</bridgehead>
+      <?dbfo list-presentation="list"?>
+      <?dbhtml list-presentation="table"?>
+
+      <varlistentry id="val-surface-sharing">
+        <term><command>val-surface-sharing</command></term>
+        <listitem>
+          <para>
+            tests the Intel Video Processing API to ensure that surface sharing
+            functionality is working correctly
+          </para>
+          <indexterm zone="libvpl-tools val-surface-sharing">
+            <primary sortas="b-val-surface-sharing">val-surface-sharing</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry id="vpl-import-export">
+        <term><command>vpl-import-export</command></term>
+        <listitem>
+          <para>
+            tests the Intel Video Processing API to ensure that the encoding
+            and decoding functionality is working correctly
+          </para>
+          <indexterm zone="libvpl-tools vpl-import-export">
+            <primary sortas="b-vpl-import-export">vpl-import-export</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry id="vpl-inspect">
+        <term><command>vpl-inspect</command></term>
+        <listitem>
+          <para>
+            prints information about the implementation of the Intel Video
+            Processing API used on a given system
+          </para>
+          <indexterm zone="libvpl-tools vpl-inspect">
+            <primary sortas="b-vpl-inspect">vpl-inspect</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry id="vpl-metrics-monitor">
+        <term><command>vpl-metrics-monitor</command></term>
+        <listitem>
+          <para>
+            monitors GPU usage when running video encoding/decoding operations
+          </para>
+          <indexterm zone="libvpl-tools vpl-metrics-monitor">
+            <primary sortas="b-vpl-metrics-monitor">vpl-metrics-monitor</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+      
+      <varlistentry id="vpl-sample-decode">
+        <term><command>vpl-sample-decode</command></term>
+        <listitem>
+          <para>
+            performs basic decoding tasks to demonstrate how to use the Intel
+            Video Processing API
+          </para>
+          <indexterm zone="libvpl-tools vpl-sample-decode">
+            <primary sortas="b-vpl-sample-decode">vpl-sample-decode</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry id="vpl-sample-encode">
+        <term><command>vpl-sample-encode</command></term>
+        <listitem>
+          <para>
+            performs basic encoding tasks to demonstrate how to use the Intel
+            Video Processing API
+          </para>
+          <indexterm zone="libvpl-tools vpl-sample-encode">
+            <primary sortas="b-vpl-sample-encode">vpl-sample-encode</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry id="vpl-sample-multi-transcode">
+        <term><command>vpl-sample-multi-transcode</command></term>
+        <listitem>
+          <para>
+            performs basic transcoding tasks to multiple video files at a time
+            to demonstrate how to use the Intel Video Processing API
+          </para>
+          <indexterm zone="libvpl-tools vpl-sample-multi-transcode">
+            <primary sortas="b-vpl-sample-multi-transcode">vpl-sample-multi-transcode</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry id="vpl-sample-vpp">
+        <term><command>vpl-sample-vpp</command></term>
+        <listitem>
+          <para>
+            performs basic tasks using the video processing procedures,
+            demonstrating how to configure pipeline operations depending on
+            the difference between input and output formats
+          </para>
+          <indexterm zone="libvpl-tools vpl-sample-vpp">
+            <primary sortas="b-vpl-sample-vpp">vpl-sample-vpp</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry id="vpl-system-analyzer">
+        <term><command>vpl-system-analyzer</command></term>
+        <listitem>
+          <para>
+            outputs diagnostic information about whether an Intel GPU is
+            supported by the Video Processing API, and which of the two
+            backends will be used at runtime
+          </para>
+          <indexterm zone="libvpl-tools vpl-system-analyzer">
+            <primary sortas="b-vpl-system-analzyer">vpl-system-analyzer</primary>
+          </indexterm>
+        </listitem>
+      </varlistentry>
+      
+    </variablelist>
+  </sect2>
+</sect1>

--- a/graph/app/libvpl-tools.xml
+++ b/graph/app/libvpl-tools.xml
@@ -44,10 +44,14 @@
       <ulink url="&blfs-svn;/multimedia/intel-media-driver.html">intel-media-driver</ulink>,
       <ulink url="&blfs-svn;/x/libdrm.html">libdrm</ulink>,
       <ulink url="&blfs-svn;/multimedia/libva.html">libva</ulink>,
-      <xref linkend="libvpl"/>,
-      <ulink url="&blfs-svn;/general/wayland.html">Wayland</ulink>,
-      <ulink url="&blfs-svn;/general/wayland-protocols.html">wayland-protocols</ulink>, and
+      <xref linkend="libvpl"/>, and
       <ulink url="&blfs-svn;/x/x7lib.html">Xorg Libraries</ulink>
+    </para>
+
+    <bridgehead renderas="sect4">Optional</bridgehead>
+    <para role="Optional">
+      <ulink url="&blfs-svn;/general/wayland.html">Wayland</ulink> and
+      <ulink url="&blfs-svn;/general/wayland-protocols.html">wayland-protocols</ulink>
     </para>
 
   </sect2>

--- a/graph/app/libvpl-tools.xml
+++ b/graph/app/libvpl-tools.xml
@@ -98,6 +98,13 @@ mv -v /usr/bin/system_analyzer        /usr/bin/vpl-system-analyzer</userinput></
 
   </sect2>
 
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    &options-cmake;
+
+  </sect2>
+
   <sect2 role="content">
     <title>Contents</title>
 

--- a/graph/app/obs-studio.xml
+++ b/graph/app/obs-studio.xml
@@ -111,7 +111,10 @@
         </listitem>
         <listitem>
           <para>
-            <ulink url="&blfs-svn;/multimedia/intel-media-driver.html">intel-media-driver</ulink>
+            <ulink url="&blfs-svn;/multimedia/intel-media-driver.html">intel-media-driver</ulink>,
+            <xref linkend="intel-mediasdk"/> (for GPUs from Broadwell to Tiger Lake),
+            <xref linkend="intel-onevpl"/> (for GPUs from Tiger Lake onward),
+            <xref linkend="libvpl"/>,
             and
             <ulink url="&blfs-svn;/x/mesa.html">Mesa</ulink>
             (required for Intel QSV11 hardware encoding)

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -44,6 +44,10 @@
       <para>August 15th, 2025</para>
       <itemizedlist>
         <listitem>
+          <para>[renodr] - intel-onevpl: Added. Part of
+          <ulink url="&slfs-issues;/190">#190</ulink>.</para>
+        </listitem>
+        <listitem>
           <para>[renodr] - Intel-MediaSDK: Added. Part of
           <ulink url="&slfs-issues;/190">#190</ulink>.</para>
         </listitem>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -44,6 +44,10 @@
       <para>August 15th, 2025</para>
       <itemizedlist>
         <listitem>
+          <para>[renodr] - libvpl-tools: Added. Part of
+          <ulink url="&slfs-issues;/190">#190</ulink>.</para>
+        </listitem>
+        <listitem>
           <para>[renodr] - libvpl: Added. Part of
           <ulink url="&slfs-issues;/190">#190</ulink>.</para>
         </listitem>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -41,6 +41,16 @@
     -->
 
     <listitem>
+      <para>August 15th, 2025</para>
+      <itemizedlist>
+        <listitem>
+          <para>[renodr] - Intel-MediaSDK: Added. Part of
+          <ulink url="&slfs-issues;/190">#190</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>August 11th, 2025</para>
       <itemizedlist>
         <listitem>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -44,6 +44,10 @@
       <para>August 15th, 2025</para>
       <itemizedlist>
         <listitem>
+          <para>[renodr] - libvpl: Added. Part of
+          <ulink url="&slfs-issues;/190">#190</ulink>.</para>
+        </listitem>
+        <listitem>
           <para>[renodr] - intel-onevpl: Added. Part of
           <ulink url="&slfs-issues;/190">#190</ulink>.</para>
         </listitem>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -44,6 +44,11 @@
       <para>August 15th, 2025</para>
       <itemizedlist>
         <listitem>
+          <para>[renodr] - OBS-Studio: updated the dependencies to add proper
+          support for Intel hardware encoding. Fixes
+          <ulink url="&slfs-issues;/190">#190</ulink>.</para>
+        </listitem>
+        <listitem>
           <para>[renodr] - libvpl-tools: Added. Part of
           <ulink url="&slfs-issues;/190">#190</ulink>.</para>
         </listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -150,6 +150,7 @@ the exact same version number... -->
 <!ENTITY rofi-wayland-version                "&rofi-version;+wayland1">
 <!ENTITY wofi-version                        "1.5.1">
 <!-- App -->
+<!ENTITY libvpl-tools-version                "1.4.0">
 <!ENTITY mesa-demos-version                  "9.0.0">
 <!ENTITY obs-studio-version                  "31.0.3">
 <!ENTITY obs-cef-version                     "6533">

--- a/packages.ent
+++ b/packages.ent
@@ -37,6 +37,7 @@
 <!-- Graphical Libraries -->
 <!ENTITY fcft-version                        "3.3.2">
 <!ENTITY glu-version                         "9.0.3">
+<!ENTITY intel-mediasdk-version              "23.2.2">
 <!ENTITY libdecor-version                    "0.2.3">
 <!ENTITY libliftoff-version                  "0.5.0">
 <!ENTITY libspng-version                     "0.7.4">

--- a/packages.ent
+++ b/packages.ent
@@ -41,6 +41,7 @@
 <!ENTITY libdecor-version                    "0.2.3">
 <!ENTITY libliftoff-version                  "0.5.0">
 <!ENTITY libspng-version                     "0.7.4">
+<!ENTITY libvpl-version                      "2.15.0">
 <!ENTITY nv-codec-headers-version            "13.0.19.0">
 <!ENTITY intel-onevpl-version                "25.3.2">
 <!ENTITY xdg-desktop-portal-hyprland-version "1.3.10">

--- a/packages.ent
+++ b/packages.ent
@@ -42,6 +42,7 @@
 <!ENTITY libliftoff-version                  "0.5.0">
 <!ENTITY libspng-version                     "0.7.4">
 <!ENTITY nv-codec-headers-version            "13.0.19.0">
+<!ENTITY intel-onevpl-version                "25.3.2">
 <!ENTITY xdg-desktop-portal-hyprland-version "1.3.10">
 <!ENTITY xdg-desktop-portal-wlr-version      "0.7.1">
 <!-- General Utilities -->


### PR DESCRIPTION
With the current instructions in the book, OBS Studio is unable to do graphics acceleration on Intel iGPUs and dedicated GPUs. The problem occurs because we were missing some of the libraries necessary to make it work. Note that the Intel Media SDK is technically archived upstream, but it is the only way to get acceleration on CPUs prior to the 11th generation CPUs. The Intel Media SDK also provides support that libvpl uses to determine which runtime to use.

Tested with OBS Studio on an Intel Core i5-6600K with effectively LFS 12.4-rc1.

Fixes: #190 