### PR TITLE
Fix the modern JDK version to match BLFS

### DIFF
--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -41,6 +41,16 @@
     -->
 
     <listitem>
+      <para>August 30th, 2025</para>
+      <itemizedlist>
+        <listitem>
+          <para>[renodr] - Update the modern JDK version entity to 24.0.2+12,
+          matching BLFS for security reasons.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>August 26th, 2025</para>
       <itemizedlist>
         <listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -250,7 +250,7 @@ the exact same version number... -->
 <!-- Minecraft -->
 <!-- Let's keep this updated for security reasons.
      - Zeckma -->
-<!ENTITY jdk-modern                          "24.0.1+9">
+<!ENTITY jdk-modern                          "24.0.2+12">
 <!ENTITY prism-launcher-version              "9.4">
 <!-- TTD -->
 <!ENTITY openttd-version                     "15.0-beta2">


### PR DESCRIPTION
The version in the book previously was 24.0.1+9, and BLFS now has 24.0.2+12. It's mostly for display, but let's make sure we're consistent :)