### PR TITLE
eza: 0.23.0 -> 0.23.1 (and document completions). Fixes #274

### DIFF
--- a/general/sysutils/eza.xml
+++ b/general/sysutils/eza.xml
@@ -89,6 +89,16 @@ for i in {1,5}; do
   install -vDm644 target/man-&eza-version;/*.$i -t /usr/share/man/man$i/
 done</userinput></screen>
 
+    <para>
+      If you wish to install shell completions, execute the relevant commands
+      for your shell(s) as the <systemitem class="username">root</systemitem>
+      user:
+    </para>
+<screen role="root"><userinput>install -vDm644 completions/bash/eza      -t /usr/share/bash-completion/completions/
+install -vDm644 completions/fish/eza.fish -t /usr/share/fish/vendor_completions.d/
+install -vDm644 completions/zsh/_eza      -t /usr/share/zsh/site-functions/
+</userinput></screen>
+
   </sect2>
 
   <sect2 role="content">

--- a/packages.ent
+++ b/packages.ent
@@ -82,7 +82,7 @@ version, so keep this at that. -->
 <!ENTITY yt-dlp-version                      "2025.07.21">
 <!-- System Utilities -->
 <!ENTITY dunst-version                       "1.12.2">
-<!ENTITY eza-version                         "0.23.0">
+<!ENTITY eza-version                         "0.23.1">
 <!ENTITY iputils-version                     "20250605">
 <!ENTITY libtree-version                     "3.1.1">
 <!ENTITY tealdeer-version                    "1.7.2">


### PR DESCRIPTION
This patch also adds instructions to install shell completions.