### PR TITLE
fastfetch: 2.51.1 -> 2.52.0. Fixes #322

### DIFF
--- a/general/genutils/fastfetch.xml
+++ b/general/genutils/fastfetch.xml
@@ -43,6 +43,7 @@
     <bridgehead renderas="sect4">Optional</bridgehead>
     <para role="optional">
       <ulink url="&blfs-svn;/x/vulkan-loader.html">Vulkan-Loader</ulink>,
+      <ulink url="&blfs-svn;/x/vulkan-headers.html">Vulkan-Headers</ulink>,
       <ulink url="&blfs-svn;/x/libxcb.html">libxcb</ulink>,
       <ulink url="&blfs-svn;/x/x7lib.html">Xorg Libraries</ulink>,
       <ulink url="&blfs-svn;/general/wayland.html">Wayland</ulink>,
@@ -72,9 +73,13 @@
 <screen><userinput>mkdir build &amp;&amp;
 cd    build &amp;&amp;
 
-cmake -D CMAKE_INSTALL_PREFIX=/usr \
-      -D CMAKE_BUILD_TYPE=Release  \
-      -D BUILD_FLASHFETCH=OFF      \
+cmake -D CMAKE_INSTALL_PREFIX=/usr    \
+      -D CMAKE_BUILD_TYPE=Release     \
+      -D BUILD_FLASHFETCH=OFF         \
+      -D PACKAGES_DISABLE_CHOCO=ON    \
+      -D PACKAGES_DISABLE_MACPORTS=ON \
+      -D PACKAGES_DISABLE_SCOOP=ON    \
+      -D PACKAGES_DISABLE_WINGET=ON   \
       ..  &amp;&amp;
 
 make</userinput></screen>
@@ -101,6 +106,14 @@ make</userinput></screen>
       <parameter>-D BUILD_FLASHFETCH=OFF</parameter>: This switch disables
       building the historical flashfetch binary. If you need it for any reason,
       set this switch to <parameter>ON</parameter>.
+    </para>
+
+    <para>
+      <parameter>-D PACKAGES_DISABLE_*=ON</parameter>: This switch disables
+      detection for various package managers. While there are more available
+      package managers, only the ones that don't support Linux have been
+      disabled. If you'd like to support these package managers, set their
+      switches to <parameter>OFF</parameter>.
     </para>
 
   </sect2>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -43,6 +43,10 @@
       <para>October 14th, 2025</para>
       <itemizedlist>
         <listitem>
+          <para>[fastfetch] - fastfetch: 2.51.1 -&gt; 2.52.0. Fixes
+          <ulink url="&slfs-issues;/278">#322</ulink>.</para>
+        </listitem>
+        <listitem>
           <para>[zeckma] - LADSPA-SDK: Added.</para>
         </listitem>
         <listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -77,7 +77,7 @@ version, so keep this at that. -->
 <!ENTITY ncdu-version                        "1.22">
 <!ENTITY ncompress-version                   "5.0">
 <!ENTITY neofetch-version                    "7.1.0">
-<!ENTITY fastfetch-version                   "2.51.1">
+<!ENTITY fastfetch-version                   "2.52.0">
 <!ENTITY rpmextract-version                  "1.0">
 <!ENTITY scdoc-version                       "1.11.3">
 <!ENTITY tmux-version                        "3.5a">


### PR DESCRIPTION
I also made some tweaks:
- Add `PACKAGE_DISABLE_*` configure options
- Add missing optional dependency on Vulkan-Headers (build-time, not necessarily present even if Vulkan-Loader is present)