### PR TITLE
yt-dlp: 2025.09.26 -> 2025.10.14. Fixes #336

### DIFF
--- a/general/genutils/yt-dlp.xml
+++ b/general/genutils/yt-dlp.xml
@@ -21,9 +21,9 @@
     <title>Introduction to yt-dlp</title>
 
     <para>
-      The yt-dlp package provides a feature-rich command-line audio/video
-      downloader, supporting thousands of websites, including YouTube. It can
-      convert downloads into other formats using FFmpeg.
+      The yt-dlp package provides a CLI utility to download audio and video
+      files from thousands of websites, including YouTube. It can convert
+      downloads into other formats using FFmpeg.
     </para>
 
     <itemizedlist spacing="compact">
@@ -103,7 +103,7 @@
         <term><command>yt-dlp</command></term>
         <listitem>
          <para>
-           is the feature-rich command-line audio and video downloader
+           downloads and converts audio and video files
          </para>
           <indexterm zone="yt-dlp yt-dlp-bin">
             <primary sortas="b-yt-dlp-bin">yt-dlp</primary>

--- a/general/genutils/yt-dlp.xml
+++ b/general/genutils/yt-dlp.xml
@@ -21,9 +21,9 @@
     <title>Introduction to yt-dlp</title>
 
     <para>
-      The yt-dlp package provides a program that can
-      download YouTube videos from their servers and convert a given downloaded
-      video into another format.
+      The yt-dlp package provides a feature-rich command-line audio/video
+      downloader, supporting thousands of websites, including YouTube. It can
+      convert downloads into other formats using FFmpeg.
     </para>
 
     <itemizedlist spacing="compact">
@@ -50,7 +50,8 @@
 
     <bridgehead renderas="sect4">Optional</bridgehead>
     <para role="optional">
-      <ulink url="&blfs-svn;/general/python-modules.html#requests">requests</ulink>
+      <ulink url="&blfs-svn;/general/python-modules.html#requests">requests</ulink> and
+      <ulink url="&blfs-svn;/general/brotli.html">brotli</ulink>
     </para>
 
   </sect2>
@@ -59,8 +60,7 @@
     <title>Installation of yt-dlp</title>
 
     <para>
-      Install yt-dlp by running the following
-      commands:
+      Install yt-dlp by running the following commands:
     </para>
 
 <screen><userinput>make yt-dlp</userinput></screen>
@@ -103,7 +103,7 @@
         <term><command>yt-dlp</command></term>
         <listitem>
          <para>
-           downloads and converts YouTube videos
+           is the feature-rich command-line audio and video downloader
          </para>
           <indexterm zone="yt-dlp yt-dlp-bin">
             <primary sortas="b-yt-dlp-bin">yt-dlp</primary>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -40,6 +40,16 @@
     -->
 
     <listitem>
+      <para>October 20th, 2025</para>
+      <itemizedlist>
+        <listitem>
+          <para>[Toxikuu] - yt-dlp: 2025.09.26 -&gt; 2025.10.14. Fixes
+          <ulink url="&slfs-issues;/336">#336</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>October 19th, 2025</para>
       <itemizedlist>
         <listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -82,7 +82,7 @@ version, so keep this at that. -->
 <!ENTITY scdoc-version                       "1.11.3">
 <!ENTITY tmux-version                        "3.5a">
 <!ENTITY winetricks-version                  "20250102">
-<!ENTITY yt-dlp-version                      "2025.09.26">
+<!ENTITY yt-dlp-version                      "2025.10.14">
 <!-- System Utilities -->
 <!ENTITY dunst-version                       "1.13.0">
 <!ENTITY eza-version                         "0.23.4">


### PR DESCRIPTION
Tweaks to the yt-dlp page:
- Documented optional brotli dependency
- Clarified scope of yt-dlp website support