### PR TITLE
Alacritty: 0.15.1 -> 0.16.1. Fixes #337

### DIFF
--- a/graph/term/alacritty.xml
+++ b/graph/term/alacritty.xml
@@ -88,6 +88,14 @@ popd</userinput></screen>
 install -vDm755 extra/logo/alacritty-term.svg /usr/share/pixmaps/Alacritty.svg  &amp;&amp;
 install -vDm644 extra/linux/Alacritty.desktop -t /usr/share/applications/</userinput></screen>
 
+    &desktop-files;
+
+    <para>
+      To ensure Alacritty's terminfo is present, run the following command as
+      the <systemitem class="username">root</systemitem> user:
+    </para>
+<screen role="root"><userinput>tic -xe alacritty,alacritty-direct extra/alacritty.info</userinput></screen>
+
     <para>
       If you wish to install shell completions, execute the relevant commands
       for your shell(s) as the <systemitem class="username">root</systemitem>
@@ -135,9 +143,9 @@ install -vm644 README.md /usr/share/doc/alacritty-&alacritty-version;</userinput
     <sect3 id="alacritty-config">
       <title>Config Files</title>
       <para>
-        <filename>~/.config/alacritty/alacritty.toml</filename>. There is no
-        default version and must be created manually. For configuration
-        options, see <ulink
+        <filename>~/.config/alacritty/alacritty.toml</filename>. If you wish to
+        configure Alacritty, manually create this file; otherwise, a default
+        configuration will be used. For configuration options, see <ulink
         url="https://alacritty.org/config-alacritty.html">alacritty(5)</ulink>,
         or if you built the man pages, run <command>man 5 alacritty</command>.
       </para>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -43,6 +43,10 @@
       <para>October 20th, 2025</para>
       <itemizedlist>
         <listitem>
+          <para>[Toxikuu] - Alacritty: 0.15.1 -&gt; 0.16.1. Fixes
+          <ulink url="&slfs-issues;/337">#337</ulink>.</para>
+        </listitem>
+        <listitem>
           <para>[Toxikuu] - yt-dlp: 2025.09.26 -&gt; 2025.10.14. Fixes
           <ulink url="&slfs-issues;/336">#336</ulink>.</para>
         </listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -150,7 +150,7 @@ version, so keep this at that. -->
 <!ENTITY xcb-util-xrm-version                "1.3">
 <!ENTITY xcb-imdkit-version                  "1.0.9">
 <!-- Terminal Emulators -->
-<!ENTITY alacritty-version                   "0.15.1">
+<!ENTITY alacritty-version                   "0.16.1">
 <!ENTITY foot-version                        "1.24.0">
 <!-- Launchers -->
 <!ENTITY rofi-version                        "2.0.0">

--- a/xent.ent
+++ b/xent.ent
@@ -52,6 +52,17 @@
   This package does not need rpath once it's installed into the standard
   location, and rpath may sometimes cause unwanted effects or even security
   issues.</para>">
+<!ENTITY desktop-files
+  "<note><para>This package installs desktop files into the <filename
+  class='directory'>/usr/share/applications</filename> hierarchy. System
+  performance and memory usage may be improved by updating
+  <filename>/usr/share/applications/mimeinfo.cache</filename> if you have
+  <ulink url='&blfs-svn;/general/desktop-file-utils.html'>desktop-file-utils</ulink>
+  installed. To perform the update, issue the following command as the
+  <systemitem class='username'>root</systemitem> user:
+
+  <screen role='root'><userinput>update-desktop-database -q</userinput></screen>
+  </para></note>">
 <!ENTITY extraction-unzip
   "<note><para>During extraction, you may get the following message(s):</para>
 <screen><computeroutput>unzip: Cannot set mode for '...': Operation notsupported</computeroutput></screen>


### PR DESCRIPTION
Changes to the Alacritty page:
- Added a note about updating the desktop database
    - Added an xent for this as it's subject to reuse
- Added a command to ensure the presence of Alacritty's terminfo
- Reworded the description for Alacritty's config file