### PR TITLE
glaze: 5.7.2 -> 6.0.0. Fixes #335

### DIFF
--- a/general/genlib/glaze.xml
+++ b/general/genlib/glaze.xml
@@ -57,7 +57,9 @@ cd    build &amp;&amp;
 
 cmake -D CMAKE_INSTALL_PREFIX=/usr \
       -D CMAKE_BUILD_TYPE=Release  \
-      -D BUILD_TESTING=OFF         \
+      -D glaze_BUILD_EXAMPLES=OFF  \
+      -D glaze_DEVELOPER_MODE=OFF  \
+      -D glaze_ENABLE_FUZZING=OFF  \
       -G Ninja .. &amp;&amp;
 
 ninja</userinput></screen>
@@ -69,13 +71,27 @@ ninja</userinput></screen>
 <screen role="root"><userinput>ninja install</userinput></screen>
 
   </sect2>
-  
+
   <sect2 role="commands">
     <title>Command Explanations</title>
 
+    <!-- Currently (v6.0.0 - 2025-10-20) unused by the build system when glaze_*
+    are passed -->
+    <!-- <para> -->
+    <!--   <parameter>-D BUILD_TESTING=OFF</parameter>: This parameter disables -->
+    <!--   building tests. -->
+    <!-- </para> -->
     <para>
-      <parameter>-D BUILD_TESTING=OFF</parameter>: This parameter disables
-      building tests.
+      <parameter>-D glaze_BUILD_EXAMPLES=OFF</parameter>: This parameter
+      disables building examples.
+    </para>
+    <para>
+      <parameter>-D glaze_DEVELOPER_MODE=OFF</parameter>: This parameter
+      disables building features targetted towards developers.
+    </para>
+    <para>
+      <parameter>-D glaze_ENABLE_FUZZING=OFF</parameter>: This parameter
+      disables fuzzing.
     </para>
 
   </sect2>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -43,6 +43,10 @@
       <para>October 20th, 2025</para>
       <itemizedlist>
         <listitem>
+          <para>[Toxikuu] - glaze: 5.7.2 -&gt; 6.0.0. Fixes
+          <ulink url="&slfs-issues;/335">#335</ulink>.</para>
+        </listitem>
+        <listitem>
           <para>[Toxikuu] - Alacritty: 0.15.1 -&gt; 0.16.1. Fixes
           <ulink url="&slfs-issues;/337">#337</ulink>.</para>
         </listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -4,7 +4,7 @@
 <!ENTITY asio-version                        "1-36-0">
 <!ENTITY enet-version                        "1.3.18">
 <!ENTITY fuse2-version                       "2.9.9">
-<!ENTITY glaze-version                       "5.7.2">
+<!ENTITY glaze-version                       "6.0.0">
 <!ENTITY iniparser-version                   "4.2.6">
 <!ENTITY libev-version                       "4.33">
 <!ENTITY libime-version                      "1.1.11">


### PR DESCRIPTION
Tweaked configure options.

The latest Hyprland (v0.51.1) builds against this without issue for me.