### PR TITLE
xdg-desktop-portal-hyprland: 1.3.10 -> 1.3.11. Fixes #340

### DIFF
--- a/general/graphlib/xdg-desktop-portal-hyprland.xml
+++ b/general/graphlib/xdg-desktop-portal-hyprland.xml
@@ -61,8 +61,8 @@
 
     <bridgehead renderas="sect4">Optional (Runtime)</bridgehead>
     <para role="optional">
-      <ulink role="runtime" url="https://archlinux.org/packages/extra/x86_64/grim/">grim</ulink> and
-      <ulink role="runtime" url="https://archlinux.org/packages/extra/x86_64/slurp/">slurp</ulink>
+      <xref role="runtime" linkend="grim"/> and
+      <xref role="runtime" linkend="slurp"/>
     </para>
 
   </sect2>
@@ -71,16 +71,27 @@
     <title>Installation of xdg-desktop-portal-hyprland</title>
 
     <para>
-      Install xdg-desktop-portal-hyprland by running
-      the following commands:
+      Install xdg-desktop-portal-hyprland by running the following commands:
     </para>
 
-<screen><userinput>rm -rf subprojects/sdbus-cpp &amp;&amp;
+<screen revision="sysv"><userinput>rm -rf subprojects           &amp;&amp;
 mkdir build                  &amp;&amp;
 cd    build                  &amp;&amp;
 
 cmake -D CMAKE_INSTALL_PREFIX=/usr \
       -D CMAKE_BUILD_TYPE=Release  \
+      -D SYSTEMD_SERVICES=OFF      \
+      -G Ninja ..            &amp;&amp;
+
+ninja</userinput></screen>
+
+<screen revision="systemd"><userinput>rm -rf subprojects           &amp;&amp;
+mkdir build                  &amp;&amp;
+cd    build                  &amp;&amp;
+
+cmake -D CMAKE_INSTALL_PREFIX=/usr \
+      -D CMAKE_BUILD_TYPE=Release  \
+      -D SYSTEMD_SERVICES=ON       \
       -G Ninja ..            &amp;&amp;
 
 ninja</userinput></screen>
@@ -89,24 +100,16 @@ ninja</userinput></screen>
       Now, as the &root; user:
     </para>
 
-<screen role="root" revision="sysv"><userinput>ninja install &amp;&amp;
-rm -rvf /usr/lib/systemd</userinput></screen>
-
-<screen role="root" revision="systemd"><userinput>ninja install</userinput></screen>
+<screen role="root"><userinput>ninja install</userinput></screen>
 
   </sect2>
-  
+
   <sect2 role="commands">
     <title>Command Explanations</title>
 
     <para>
-      <command>rm -rf subprojects/sdbus-cpp</command>: This command removes
-      vendored source code that FTBFS.
-    </para>
-
-    <para revision="sysv">
-      <command>rm -rvf /usr/lib/systemd</command>: This command removes
-      unnecessary Systemd files.
+      <command>rm -rf subprojects</command>: This command removes vendored
+      source code.
     </para>
 
   </sect2>
@@ -153,8 +156,7 @@ rm -rvf /usr/lib/systemd</userinput></screen>
         <term><command>xdg-desktop-portal-hyprland</command></term>
         <listitem>
           <para>
-            allows you to access portals in a
-            Hyprland session
+            allows you to access portals in a Hyprland session
           </para>
           <indexterm zone="xdg-desktop-portal-hyprland xdg-desktop-portal-hyprland-bin">
             <primary sortas="b-xdg-desktop-portal-hyprland-bin">xdg-desktop-portal-hyprland</primary>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -40,6 +40,16 @@
     -->
 
     <listitem>
+      <para>October 27th, 2025</para>
+      <itemizedlist>
+        <listitem>
+          <para>[Toxikuu] - xdg-desktop-portal-hyprland: 1.3.10 -> 1.3.11. Fixes
+          <ulink url="&slfs-issues;/340">#340</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>October 23rd, 2025</para>
       <itemizedlist>
         <listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -45,7 +45,7 @@
 <!ENTITY libvpl-version                      "2.15.0">
 <!ENTITY nv-codec-headers-version            "13.0.19.0">
 <!ENTITY intel-onevpl-version                "25.4.1">
-<!ENTITY xdg-desktop-portal-hyprland-version "1.3.10">
+<!ENTITY xdg-desktop-portal-hyprland-version "1.3.11">
 <!ENTITY xdg-desktop-portal-wlr-version      "0.7.1">
 <!-- General Utilities -->
 <!ENTITY cava-version                        "0.10.6">


### PR DESCRIPTION
Tweaks:
- Reference internal grim and slurp
- Devendor all subprojects (currently sdbus-cpp and hyprland-protocols, both required dependencies)
- Pass `-D SYSTEMD_SERVICES`
- Adjust command explanations
- Formatting