### PR TITLE
*: Add missing command explanations for meson

### DIFF
--- a/general/genlib/libsrtp.xml
+++ b/general/genlib/libsrtp.xml
@@ -74,6 +74,13 @@ ninja</userinput></screen>
 
   </sect2>
 
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    &meson-buildtype-release;
+
+  </sect2>
+
   <sect2 role="content">
     <title>Contents</title>
 

--- a/general/genlib/msgraph.xml
+++ b/general/genlib/msgraph.xml
@@ -81,6 +81,13 @@ ninja</userinput></screen>
 
   </sect2>
 
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    &meson-buildtype-release;
+
+  </sect2>
+
   <sect2 role="using">
     <title>Using msgraph</title>
 

--- a/general/genlib/tllist.xml
+++ b/general/genlib/tllist.xml
@@ -57,6 +57,13 @@ ninja</userinput></screen>
 
   </sect2>
 
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    &meson-buildtype-release;
+
+  </sect2>
+
   <sect2 role="content">
     <title>Contents</title>
 

--- a/general/genlib/tomlplusplus.xml
+++ b/general/genlib/tomlplusplus.xml
@@ -65,6 +65,9 @@ ninja</userinput></screen>
 
   <sect2 role="commands">
     <title>Command Explanations</title>
+
+    &meson-buildtype-release;
+
     <para><option>-D generate_cmake_config=false</option>: This option
     disables depending on CMake but as a result doesn't generate CMake
     find_package files some build systems require.</para>

--- a/general/graphlib/fcft.xml
+++ b/general/graphlib/fcft.xml
@@ -88,6 +88,13 @@ ninja</userinput></screen>
 
   </sect2>
 
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    &meson-buildtype-release;
+
+  </sect2>
+
   <sect2 role="content">
     <title>Contents</title>
 

--- a/general/graphlib/libdecor.xml
+++ b/general/graphlib/libdecor.xml
@@ -87,6 +87,8 @@ ninja</userinput></screen>
   <sect2 role="commands">
     <title>Command Explanations</title>
 
+    &meson-buildtype-release;
+
     <para>
       <parameter>-D demo=false</parameter>: This parameter disables building
       the demos. Remove it if you installed the optional dependencies.

--- a/general/graphlib/libliftoff.xml
+++ b/general/graphlib/libliftoff.xml
@@ -62,6 +62,13 @@ ninja</userinput></screen>
 
   </sect2>
 
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    &meson-buildtype-release;
+
+  </sect2>
+
   <sect2 role="content">
     <title>Contents</title>
 

--- a/general/graphlib/xdg-desktop-portal-wlr.xml
+++ b/general/graphlib/xdg-desktop-portal-wlr.xml
@@ -99,6 +99,13 @@ EOF</userinput></screen>
 
   </sect2>
 
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    &meson-buildtype-release;
+
+  </sect2>
+
   <sect2 role="content">
     <title>Contents</title>
 

--- a/general/mm-lib/rubberband.xml
+++ b/general/mm-lib/rubberband.xml
@@ -105,6 +105,8 @@ rm -vf /usr/lib/librubberband.a</userinput></screen>
   <sect2 role="commands">
     <title>Command Explanations</title>
 
+    &meson-buildtype-release;
+
     <para>
       <option>-D resampler=</option>: This option can be used to specify the
       resampler to use. By default, it will use the built-in implementation.

--- a/graph/app/grim.xml
+++ b/graph/app/grim.xml
@@ -77,6 +77,13 @@ ninja</userinput></screen>
 
   </sect2>
 
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    &meson-buildtype-release;
+
+  </sect2>
+
   <sect2 role="content">
     <title>Contents</title>
 

--- a/graph/app/mesa-demos.xml
+++ b/graph/app/mesa-demos.xml
@@ -188,6 +188,13 @@ cp -vR DESTDIR/usr/share/* /usr/share</userinput></screen>
 
   </sect2>
 
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    &meson-buildtype-release;
+
+  </sect2>
+
   <sect2 role="content">
     <title>Contents</title>
 

--- a/graph/app/slurp.xml
+++ b/graph/app/slurp.xml
@@ -73,6 +73,13 @@ ninja</userinput></screen>
 
   </sect2>
 
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    &meson-buildtype-release;
+
+  </sect2>
+
   <sect2 role="content">
     <title>Contents</title>
 

--- a/graph/app/wbg.xml
+++ b/graph/app/wbg.xml
@@ -85,6 +85,13 @@ ninja</userinput></screen>
 
   </sect2>
 
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    &meson-buildtype-release;
+
+  </sect2>
+
   <sect2 role="content">
     <title>Contents</title>
 

--- a/graph/launch/rofi.xml
+++ b/graph/launch/rofi.xml
@@ -93,6 +93,13 @@ ninja</userinput></screen>
 
   </sect2>
 
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    &meson-buildtype-release;
+
+  </sect2>
+
   <sect2 role="content">
     <title>Contents</title>
 

--- a/graph/launch/wofi.xml
+++ b/graph/launch/wofi.xml
@@ -70,6 +70,13 @@ ninja</userinput></screen>
 
   </sect2>
 
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    &meson-buildtype-release;
+
+  </sect2>
+
   <sect2 role="content">
     <title>Contents</title>
 

--- a/graph/term/foot.xml
+++ b/graph/term/foot.xml
@@ -90,6 +90,13 @@ ninja</userinput></screen>
 
   </sect2>
 
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    &meson-buildtype-release;
+
+  </sect2>
+
   <sect2 role="configuration">
     <title>Configuring foot</title>
 

--- a/graph/tk/scenefx.xml
+++ b/graph/tk/scenefx.xml
@@ -73,6 +73,13 @@ ninja</userinput></screen>
 
   </sect2>
 
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    &meson-buildtype-release;
+
+  </sect2>
+
   <sect2 role="content">
     <title>Contents</title>
 

--- a/graph/tk/wlroots.xml
+++ b/graph/tk/wlroots.xml
@@ -152,6 +152,8 @@ ninja</userinput></screen>
   <sect2 role="commands">
     <title>Command Explanations</title>
 
+    &meson-buildtype-release;
+
     &meson-wrap-nofallback;
 
   </sect2>

--- a/wm/i3/i3-wm.xml
+++ b/wm/i3/i3-wm.xml
@@ -99,6 +99,8 @@ mv -v /usr/share/doc/i3{,-&i3-version;}</userinput></screen>
   <sect2 role="commands">
     <title>Command Explanations</title>
 
+    &meson-buildtype-release;
+
     <para>
       <command>mv -v /usr/share/doc/i3{,-&i3-version;}</command>: This command
       makes the doc directory versioned to be consistent with other packages.

--- a/wm/mangowc/mangowc-wm.xml
+++ b/wm/mangowc/mangowc-wm.xml
@@ -79,6 +79,13 @@ ninja</userinput></screen>
 
   </sect2>
 
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    &meson-buildtype-release;
+
+  </sect2>
+
   <sect2 role="configuration">
     <title>Configuring MangoWC</title>
 

--- a/wm/wf/wayfire-plugins-extra.xml
+++ b/wm/wf/wayfire-plugins-extra.xml
@@ -77,6 +77,13 @@ ninja</userinput></screen>
 
   </sect2>
 
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    &meson-buildtype-release;
+
+  </sect2>
+
   <sect2 role="content">
     <title>Contents</title>
 

--- a/wm/wf/wayfire.xml
+++ b/wm/wf/wayfire.xml
@@ -119,6 +119,8 @@ ninja</userinput></screen>
   <sect2 role="commands">
     <title>Command Explanations</title>
 
+    &meson-buildtype-release;
+
     <para>
       <parameter>-D use_system_wfconfig=enabled</parameter>: This parameter
       ensures the system-installed <xref linkend="wf-config"/>.

--- a/wm/wf/wf-config.xml
+++ b/wm/wf/wf-config.xml
@@ -76,6 +76,13 @@ ninja</userinput></screen>
 
   </sect2>
 
+  <sect2 role="commands">
+    <title>Command Explanations</title>
+
+    &meson-buildtype-release;
+
+  </sect2>
+
   <sect2 role="content">
     <title>Contents</title>
 


### PR DESCRIPTION
This patch adds the `&meson-buildtype-release;` xent to pages missing it.

For future reference, the following command finds such pages (assuming `shopt -s globstar` has been run):
```bash
rg --files-with-matches -- '--buildtype=release' **/*.xml |
    xargs rg --files-without-match -F '&meson-buildtype-release;' |
    sort
```