### PR TITLE
Rewrite GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-package.yml
+++ b/.github/ISSUE_TEMPLATE/add-package.yml
@@ -1,0 +1,71 @@
+name: Add package (new)
+description: Request a package be added
+title: "Add "
+labels: [new package]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        <div align="center">
+          <img src="https://github.com/glfs-book/slfs/blob/trunk/images/slfs-logo.svg?raw=true" width="10%">
+          <h1>SLFS</h1>
+        </dev>
+
+        ### Add package
+
+  - type: input
+    id: name
+    attributes:
+      label: Name
+      description: The name of the package.
+      placeholder: Nushell
+    validations:
+      required: true
+
+  - type: input
+    id: upstream
+    attributes:
+      label: Upstream
+      description: A link to the project's upstream.
+      placeholder: https://github.com/nushell/nushell
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A brief description of the package and how it fits into SLFS.
+      placeholder: |
+        Nu is a modern, structured, functional shell written in rust. Its inclusion in SLFS helps fill out the shells chapter.
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: What does this package depend on?
+      placeholder: |
+        - Rustc (required)
+        - cURL (optional)
+    validations:
+      required: false
+
+  - type: textarea
+    id: dependants
+    attributes:
+      label: Dependants
+      description: Does anything depend on this package?
+      placeholder: |
+        No
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Extra information
+      description: Anything else we should know.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/update-package.yml
+++ b/.github/ISSUE_TEMPLATE/update-package.yml
@@ -1,0 +1,139 @@
+name: Update package (new)
+description: Report an outdated package
+title: "Update "
+labels: [update]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        <div align="center">
+          <img src="https://github.com/glfs-book/slfs/blob/trunk/images/slfs-logo.svg?raw=true" width="10%">
+          <h1>SLFS</h1>
+        </dev>
+
+        ### Update package
+
+  - type: input
+    id: name
+    attributes:
+      label: Name
+      description: The name of the package.
+      placeholder: Nushell
+    validations:
+      required: true
+
+  - type: input
+    id: new_version
+    attributes:
+      label: New version
+      description: The new version of the package.
+      placeholder: 0.109.1
+    validations:
+      required: true
+
+  - type: dropdown
+    id: semver
+    attributes:
+      label: Semantic version bump
+      description: How big is the version bump in this update?
+      options:
+        - Major
+        - Minor
+        - Patch
+        - Nano
+        - Commit
+        - Other
+      default: 2
+    validations:
+      required: true
+
+  - type: textarea
+    id: security
+    attributes:
+      label: Security
+      description: Does this release fix a security vulnerability?
+    validations:
+      required: false
+
+  - type: input
+    id: release
+    attributes:
+      label: Release
+      description: A link to the new release.
+      placeholder: https://github.com/nushell/nushell/releases/tag/0.109.1
+    validations:
+      required: false
+
+  - type: textarea
+    id: changelog
+    attributes:
+      label: Changelog
+      description: The changelog for the new release.
+      placeholder: |
+        # Nushell 0.109.1
+
+        Today, we're releasing version 0.109.1 of Nu. This release fixes some regressions of Nu 0.109.0, especially fixes to `http get` and `source`.
+
+        # Where to get it
+
+        Nu 0.109.1 is available as [pre-built binaries](https://github.com/nushell/nushell/releases/tag/0.109.1) or from [crates.io](https://crates.io/crates/nu). If you have Rust installed you can install it using `cargo install nu`.
+
+        As part of this release, we also publish a set of optional [plugins](https://www.nushell.sh/book/plugins.html) you can install and use with Nushell.
+
+        # Table of contents
+
+        - [_Changes_](#changes-toc)
+          - [_Bug fixes_](#bug-fixes-toc)
+            - [_Fix `http get` domain overflow_](#fix-http-get-domain-overflow-toc)
+            - [_Fix path resolution for `source` using bare-word-string-interpolation_](#fix-path-resolution-for-source-using-bare-word-string-interpolation-toc)
+        - [_Notes for plugin developers_](#notes-for-plugin-developers-toc)
+        - [_Hall of fame_](#hall-of-fame-toc)
+        - [_Full changelog_](#full-changelog-toc)
+
+        # Changes [[toc](#table-of-contents)]
+
+        ## Bug fixes [[toc](#table-of-contents)]
+
+        ### Fix `http get` domain overflow [[toc](#table-of-contents)]
+
+        The dns resolution #17030 implemented in v0.109.0 for `http get` could overflow an array for domains with a lot of resolved IPs. This is fixed now by truncating the resolved IP amount.
+
+        ### Fix path resolution for `source` using bare-word-string-interpolation [[toc](#table-of-contents)]
+
+        Fixed a regression in v0.109.0 that disallowed using patterns like:
+
+        ```nu
+          source config/($nu.os-info.name).nu
+        ```
+
+        # Notes for plugin developers [[toc](#table-of-contents)]
+
+        # Hall of fame [[toc](#table-of-contents)]
+
+        Thanks to all the contributors below for helping us solve issues, improve documentation, refactor code, and more! :pray:
+
+        | author                                     | change                                       | link                                                    |
+        | ------------------------------------------ | -------------------------------------------- | ------------------------------------------------------- |
+        | [@hustcer](https://github.com/hustcer)     | Bump to dev version 0.109.1                  | [#17093](https://github.com/nushell/nushell/pull/17093) |
+        | [@hustcer](https://github.com/hustcer)     | Try to fix winget automatic validation error | [#17096](https://github.com/nushell/nushell/pull/17096) |
+        | [@KaiSforza](https://github.com/KaiSforza) | Add backticks to readmes                     | [#17101](https://github.com/nushell/nushell/pull/17101) |
+
+        # Full changelog [[toc](#table-of-contents)]
+
+        | author                                     | title                                                    | link                                                    |
+        | ------------------------------------------ | -------------------------------------------------------- | ------------------------------------------------------- |
+        | [@KaiSforza](https://github.com/KaiSforza) | Add backticks to readmes                                 | [#17101](https://github.com/nushell/nushell/pull/17101) |
+        | [@hustcer](https://github.com/hustcer)     | Fix http get panic                                       | [#17092](https://github.com/nushell/nushell/pull/17092) |
+        | [@hustcer](https://github.com/hustcer)     | Bump to dev version 0.109.1                              | [#17093](https://github.com/nushell/nushell/pull/17093) |
+        | [@hustcer](https://github.com/hustcer)     | Fix use constants in bare-word-strings with source error | [#17094](https://github.com/nushell/nushell/pull/17094) |
+        | [@hustcer](https://github.com/hustcer)     | Try to fix winget automatic validation error             | [#17096](https://github.com/nushell/nushell/pull/17096) |
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Extra information
+      description: Anything else we should know.
+    validations:
+      required: false


### PR DESCRIPTION
This patch rewrites the templates for adding and updating packages using [GitHub's issue form YAML syntax](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms). It retains the old templates as we've yet to trial the new ones.