### PR TITLE
Change title placeholder for update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/update-package.yml
+++ b/.github/ISSUE_TEMPLATE/update-package.yml
@@ -1,6 +1,6 @@
 name: Update package (new)
 description: Report an outdated package
-title: "Update "
+title: "package: old -> new"
 labels: [update]
 body:
   - type: markdown


### PR DESCRIPTION
The title could probably be automatically populated using a GitHub Action that parsed packages.ent and the issue body, but this would probably be more effort than it's worth.