### PR TITLE
sdl12-compat: 1.2.74 -> 1.2.76. Fixes #623

### DIFF
--- a/download/sdl
+++ b/download/sdl
@@ -1,0 +1,1 @@
+sdl12-compat/

--- a/download/sdl12-compat/sdl12-compat-1.2.76-skip-static-1.patch
+++ b/download/sdl12-compat/sdl12-compat-1.2.76-skip-static-1.patch
@@ -1,0 +1,40 @@
+diff -Naur sdl12-compat-release-1.2.76.orig/CMakeLists.txt sdl12-compat-release-1.2.76/CMakeLists.txt
+--- sdl12-compat-release-1.2.76.orig/CMakeLists.txt	2026-04-03 19:40:25.000000000 -0500
++++ sdl12-compat-release-1.2.76/CMakeLists.txt	2026-04-03 21:33:23.956836223 -0500
+@@ -145,35 +145,11 @@
+     endforeach(flag_var)
+ endif()
+ 
+-# SDLmain library...
+-if(APPLE)
+-    add_library(SDLmain STATIC src/SDLmain/macosx/SDLMain.m)
+-    set_source_files_properties(src/SDLmain/macosx/SDLMain.m PROPERTIES LANGUAGE C)
+-    if(NOT CMAKE_VERSION VERSION_LESS "3.16")
+-        set_source_files_properties("src/SDLmain/macosx/SDLMain.m" PROPERTIES LANGUAGE OBJC)
+-    endif()
+-elseif(WIN32)
+-    add_library(SDLmain STATIC src/SDLmain/win32/SDL_win32_main.c)
+-    set_target_properties(SDLmain PROPERTIES COMPILE_DEFINITIONS "_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE")  # !!! FIXME: don't use C runtime? We fixed this in SDL2.
+-else()
+-    add_library(SDLmain STATIC src/SDLmain/dummy/SDL_dummy_main.c)
+-endif()
+-add_library(SDL::SDLmain ALIAS SDLmain)
+-target_include_directories(SDLmain PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/SDL>")
+-target_include_directories(SDLmain PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/SDL>")
+-if(MINGW OR CYGWIN)
+-    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+-        target_link_libraries(SDLmain PUBLIC "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:-Wl,--undefined=_WinMain@16>")
+-    else()
+-        target_link_libraries(SDLmain PUBLIC "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:-Wl,--undefined=WinMain>")
+-    endif()
+-endif()
+-
+ if(SDL12TESTS)
+     add_subdirectory(test)
+ endif()
+ 
+-install(TARGETS SDL SDLmain
++install(TARGETS SDL
+   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/general/mm-lib/sdl.xml
+++ b/general/mm-lib/sdl.xml
@@ -21,7 +21,7 @@
 
     <para>
       This package provides an SDL-1.2 compatibility layer using SDL-2 as a
-      backend that need it.
+      backend.
     </para>
 
     <bridgehead renderas="sect3">Package Information</bridgehead>
@@ -33,7 +33,17 @@
       </listitem>
     </itemizedlist>
 
-    <bridgehead renderas="sect3">SDL Dependencies</bridgehead>
+    <bridgehead renderas="sect3">Additional Downloads</bridgehead>
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          Recommended patch:
+          <ulink url="&dl-root;/sdl12-compat/sdl12-compat-&sdl-version;-skip-static-1.patch"/>
+        </para>
+      </listitem>
+    </itemizedlist>
+
+    <bridgehead renderas="sect3">sdl12-compat Dependencies</bridgehead>
 
     <bridgehead renderas="sect4">Required</bridgehead>
     <para role="required">
@@ -45,6 +55,12 @@
 
   <sect2 role="installation">
     <title>Installation of sdl12-compat</title>
+
+    <para>
+      Patch out the build of the <filename>libSDL.a</filename> static library:
+    </para>
+
+<screen><userinput>patch -Np1 -i ../sdl12-compat-&sdl-version;-skip-static-1.patch</userinput></screen>
 
     <para>
       Install <application>sdl12-compat</application> by running the
@@ -64,13 +80,13 @@ ninja</userinput></screen>
       Now, as the &root; user:
     </para>
 
-<screen role="root"><userinput>ninja install &amp;&amp;
-rm -vf /usr/lib/libSDLmain.a</userinput></screen>
+<screen role="root"><userinput>ninja install</userinput></screen>
 
   </sect2>
 
   <sect2 role="commands">
     <title>Command Explanations</title>
+
     <para><parameter>-D SDL12TESTS=OFF</parameter>: This parameter disables
     building several tests.</para>
   </sect2>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -43,6 +43,10 @@
       <para>April 3rd, 2026</para>
       <itemizedlist>
         <listitem>
+          <para>[tox] - sdl12-compat: 1.2.74 -&gt; 1.2.76. Fixes
+          <ulink url="&slfs-issues;/623">#623</ulink>.</para>
+        </listitem>
+        <listitem>
           <para>[tox] - tinyxxd: 1.3.14 -&gt; 1.3.15. Fixes
           <ulink url="&slfs-issues;/618">#618</ulink>.</para>
         </listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -170,7 +170,7 @@ version, so keep this at that. -->
 <!ENTITY ladspa-sdk-version                  "1.17">
 <!ENTITY noise-suppression-version           "1.10">
 <!ENTITY rubberband-version                  "4.0.0">
-<!ENTITY sdl-version                         "1.2.74">
+<!ENTITY sdl-version                         "1.2.76">
 
 <!-- SERVERS -->
 <!-- Major Servers -->


### PR DESCRIPTION
Other notable changes:
- Patch out the static library target from `CMakeLists.txt`.
- Consistently use sdl12-compat instead of SDL in headings.
- Remove an unfinished dependent clause from introduction.