### PR TITLE
Alacritty: 0.16.1 -> 0.17.0. Fixes #630

### DIFF
--- a/graph/term/alacritty.xml
+++ b/graph/term/alacritty.xml
@@ -108,8 +108,9 @@ install -vDm644 extra/completions/alacritty.fish -t /usr/share/fish/vendor_compl
       If you built the man pages, install them as the
       <systemitem class="username">root</systemitem> user:
     </para>
-<screen role="root"><userinput>install -vDm644 extra/man/*.1 -t /usr/share/man/man1/ &amp;&amp;
-install -vDm644 extra/man/*.5 -t /usr/share/man/man5/</userinput></screen>
+<screen role="root"><userinput>for f in extra/man/*.{1..8}; do
+    install -vDm644 $f -t /usr/share/man/man${f##*.}/
+done</userinput></screen>
 
     <para>
       If you wish to install the documentation, execute the following as the

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -43,6 +43,10 @@
       <para>April 7th, 2026</para>
       <itemizedlist>
         <listitem>
+          <para>[tox] - Alacritty: 0.16.1 -&gt; 0.17.0. Fixes
+          <ulink url="&slfs-issues;/630">#630</ulink>.</para>
+        </listitem>
+        <listitem>
           <para>[zeckma] - Fcitx5: 5.1.17 -&gt; 5.1.19. Fixes
           <ulink url="&slfs-issues;/591">#591</ulink>.</para>
         </listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -200,7 +200,7 @@ version, so keep this at that. -->
 <!ENTITY xcb-util-xrm-version                "1.3">
 <!ENTITY xcb-imdkit-version                  "1.0.9">
 <!-- Terminal Emulators -->
-<!ENTITY alacritty-version                   "0.16.1">
+<!ENTITY alacritty-version                   "0.17.0">
 <!ENTITY foot-version                        "1.26.1">
 <!-- Launchers -->
 <!ENTITY rofi-version                        "2.0.0">


### PR DESCRIPTION
The only notable packaging change is the new `alacritty-escapes(7)` manpage. I tweaked the manpage installation logic to work with any future sections, matching the `scdoc` commands.