### PR TITLE
Remove BLFS SQLite links

### DIFF
--- a/emu/game-emu/mgba.xml
+++ b/emu/game-emu/mgba.xml
@@ -47,10 +47,9 @@
     <para role="recommended">
       <ulink url="&blfs-svn;/general/desktop-file-utils.html">desktop-file-utils</ulink>,
       <ulink url="&blfs-svn;/multimedia/ffmpeg.html">FFmpeg</ulink>,
-      <ulink url="&blfs-svn;/general/lua.html">Lua</ulink>,
+      <ulink url="&blfs-svn;/general/lua.html">Lua</ulink>, and
       <ulink url="&blfs-svn;/x/qt6.html">Qt-6</ulink> and/or
-      &sdl2; (for the frontends), and
-      <ulink url="&blfs-svn;/server/sqlite.html">SQLite</ulink>
+      &sdl2; (for the frontends)
     </para>
 
     <bridgehead renderas="sect4">Optional</bridgehead>

--- a/general/genutils/fastfetch.xml
+++ b/general/genutils/fastfetch.xml
@@ -54,7 +54,6 @@
       &opengl;,
       <ulink url="&glfs-website;/shareddeps/ocl-icd.html">OCL-ICD</ulink>,
       <ulink url="&blfs-svn;/xfce/xfconf.html">Xfconf</ulink>,
-      <ulink url="&blfs-svn;/server/sqlite.html">SQLite</ulink>,
       <ulink url="&blfs-svn;/multimedia/pulseaudio.html">PulseAudio</ulink>,
       <ulink url="&arch-pkgs;/extra/x86_64/ddcutil/">ddcutil</ulink> and
       <ulink url="&arch-pkgs;/extra/x86_64/directx-headers/">DirectX-Headers


### PR DESCRIPTION
SQLite is included in LFS, and the BLFS links are dead.