### PR TITLE
pycurl: 7.45.7 -> 7.46.0. Fixes #680

### DIFF
--- a/general/prog/python-dependencies/pycurl.xml
+++ b/general/prog/python-dependencies/pycurl.xml
@@ -44,6 +44,10 @@
     <sect3 role="installation">
       <title>Installation of pycurl</title>
 
+      <para>Patch the path of the installed documentation:</para>
+
+<screen><userinput>sed -i 's/datadir = os.path.join("share", "doc", PACKAGE/&amp;+"-"+VERSION/' setup.py</userinput></screen>
+
       <para>Build the module:</para>
 
       &build-wheel;
@@ -52,8 +56,7 @@
         Now, as the &root; user:
       </para>
 
-<screen role="root"><userinput>&install-wheel; pycurl &amp;&amp;
-mv -v /usr/share/doc/pycurl{,-&pycurl-version;}</userinput></screen>
+<screen role="root"><userinput>&install-wheel; pycurl</userinput></screen>
 
     </sect3>
 

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -43,6 +43,10 @@
       <para>April 28th, 2026</para>
       <itemizedlist>
         <listitem>
+          <para>[tox] - pycurl: 7.45.7 -&gt; 7.46.0. Fixes
+          <ulink url="&slfs-issues;/680">#680</ulink>.</para>
+        </listitem>
+        <listitem>
           <para>[tox] - strace: 6.19 -&gt; 7.0. Fixes
           <ulink url="&slfs-issues;/668">#668</ulink>.</para>
         </listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -140,7 +140,7 @@ version, so keep this at that. -->
 <!-- Python Dependencies -->
 <!ENTITY structlog-version                   "25.5.0">
 <!ENTITY platformdirs-version                "4.9.6">
-<!ENTITY pycurl-version                      "7.45.7">
+<!ENTITY pycurl-version                      "7.46.0">
 <!ENTITY toml-version                        "0.10.2">
 <!ENTITY tornado-version                     "6.5.5">
 <!-- Python Modules -->


### PR DESCRIPTION
I ended up just building from the GitHub tag tarball.

I followed the first example from http://pycurl.io/docs/latest/quickstart.html as a sanity check, and received the body.