### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-package.yml
+++ b/.github/ISSUE_TEMPLATE/add-package.yml
@@ -14,15 +14,6 @@ body:
         ### Add package
 
   - type: input
-    id: name
-    attributes:
-      label: Name
-      description: The name of the package.
-      placeholder: Nushell
-    validations:
-      required: true
-
-  - type: input
     id: upstream
     attributes:
       label: Upstream
@@ -56,9 +47,7 @@ body:
     id: dependants
     attributes:
       label: Dependants
-      description: Does anything depend on this package?
-      placeholder: |
-        No
+      description: What depends on this package?
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/update-package.yml
+++ b/.github/ISSUE_TEMPLATE/update-package.yml
@@ -13,24 +13,6 @@ body:
 
         ### Update package
 
-  - type: input
-    id: name
-    attributes:
-      label: Name
-      description: The name of the package.
-      placeholder: Nushell
-    validations:
-      required: true
-
-  - type: input
-    id: new_version
-    attributes:
-      label: New version
-      description: The new version of the package.
-      placeholder: 0.109.1
-    validations:
-      required: true
-
   - type: dropdown
     id: semver
     attributes:
@@ -47,14 +29,6 @@ body:
     validations:
       required: true
 
-  - type: textarea
-    id: security
-    attributes:
-      label: Security
-      description: Does this release fix a security vulnerability?
-    validations:
-      required: false
-
   - type: input
     id: release
     attributes:
@@ -64,71 +38,26 @@ body:
     validations:
       required: false
 
-  - type: textarea
+  - type: input
     id: changelog
     attributes:
       label: Changelog
-      description: The changelog for the new release.
-      placeholder: |
-        # Nushell 0.109.1
-
-        Today, we're releasing version 0.109.1 of Nu. This release fixes some regressions of Nu 0.109.0, especially fixes to `http get` and `source`.
-
-        # Where to get it
-
-        Nu 0.109.1 is available as [pre-built binaries](https://github.com/nushell/nushell/releases/tag/0.109.1) or from [crates.io](https://crates.io/crates/nu). If you have Rust installed you can install it using `cargo install nu`.
-
-        As part of this release, we also publish a set of optional [plugins](https://www.nushell.sh/book/plugins.html) you can install and use with Nushell.
-
-        # Table of contents
-
-        - [_Changes_](#changes-toc)
-          - [_Bug fixes_](#bug-fixes-toc)
-            - [_Fix `http get` domain overflow_](#fix-http-get-domain-overflow-toc)
-            - [_Fix path resolution for `source` using bare-word-string-interpolation_](#fix-path-resolution-for-source-using-bare-word-string-interpolation-toc)
-        - [_Notes for plugin developers_](#notes-for-plugin-developers-toc)
-        - [_Hall of fame_](#hall-of-fame-toc)
-        - [_Full changelog_](#full-changelog-toc)
-
-        # Changes [[toc](#table-of-contents)]
-
-        ## Bug fixes [[toc](#table-of-contents)]
-
-        ### Fix `http get` domain overflow [[toc](#table-of-contents)]
-
-        The dns resolution #17030 implemented in v0.109.0 for `http get` could overflow an array for domains with a lot of resolved IPs. This is fixed now by truncating the resolved IP amount.
-
-        ### Fix path resolution for `source` using bare-word-string-interpolation [[toc](#table-of-contents)]
-
-        Fixed a regression in v0.109.0 that disallowed using patterns like:
-
-        ```nu
-          source config/($nu.os-info.name).nu
-        ```
-
-        # Notes for plugin developers [[toc](#table-of-contents)]
-
-        # Hall of fame [[toc](#table-of-contents)]
-
-        Thanks to all the contributors below for helping us solve issues, improve documentation, refactor code, and more! :pray:
-
-        | author                                     | change                                       | link                                                    |
-        | ------------------------------------------ | -------------------------------------------- | ------------------------------------------------------- |
-        | [@hustcer](https://github.com/hustcer)     | Bump to dev version 0.109.1                  | [#17093](https://github.com/nushell/nushell/pull/17093) |
-        | [@hustcer](https://github.com/hustcer)     | Try to fix winget automatic validation error | [#17096](https://github.com/nushell/nushell/pull/17096) |
-        | [@KaiSforza](https://github.com/KaiSforza) | Add backticks to readmes                     | [#17101](https://github.com/nushell/nushell/pull/17101) |
-
-        # Full changelog [[toc](#table-of-contents)]
-
-        | author                                     | title                                                    | link                                                    |
-        | ------------------------------------------ | -------------------------------------------------------- | ------------------------------------------------------- |
-        | [@KaiSforza](https://github.com/KaiSforza) | Add backticks to readmes                                 | [#17101](https://github.com/nushell/nushell/pull/17101) |
-        | [@hustcer](https://github.com/hustcer)     | Fix http get panic                                       | [#17092](https://github.com/nushell/nushell/pull/17092) |
-        | [@hustcer](https://github.com/hustcer)     | Bump to dev version 0.109.1                              | [#17093](https://github.com/nushell/nushell/pull/17093) |
-        | [@hustcer](https://github.com/hustcer)     | Fix use constants in bare-word-strings with source error | [#17094](https://github.com/nushell/nushell/pull/17094) |
-        | [@hustcer](https://github.com/hustcer)     | Try to fix winget automatic validation error             | [#17096](https://github.com/nushell/nushell/pull/17096) |
+      description: A link to the changelog.
+      placeholder: https://www.nushell.sh/blog/2025-12-02-nushell_v0_109_1.html#changes-toc
     validations:
       required: false
+
+  - type: dropdown
+    id: security
+    attributes:
+      label: Security
+      description: Does this release fix a security vulnerability?
+      options:
+        - 'yes'
+        - 'no'
+      default: 1
+    validations:
+      required: true
 
   - type: textarea
     id: extra


### PR DESCRIPTION
The changes here are informed by my UX with the templates:
- I prefer just linking to changelogs to avoid formatting issues
- Writing the package name and new version twice is redundant
- Some descriptions were worded inconsistently
- I prefer a dropdown menu to large text boxes

See also #150, #446.