### PR TITLE
fastfetch: 2.62.1 -> 2.63.1. Fixes #703

### DIFF
--- a/general/genutils/fastfetch.xml
+++ b/general/genutils/fastfetch.xml
@@ -20,8 +20,8 @@
     <title>Introduction to fastfetch</title>
 
     <para>
-      Fastfetch is a maintained, feature-rich and
-      performance oriented system information tool. It is an alternative to
+      Fastfetch is a maintained, feature-rich, and
+      performance-oriented system information tool. It is an alternative to
       <xref linkend="neofetch"/> and written in C.
     </para>
 
@@ -40,6 +40,11 @@
       <ulink url="&blfs-svn;/general/cmake.html">CMake</ulink>
     </para>
 
+    <bridgehead renderas="sect4">Recommended</bridgehead>
+    <para role="recommended">
+      <xref linkend="yyjson"/> (or a vendored copy is used)
+    </para>
+
     <bridgehead renderas="sect4">Optional</bridgehead>
     <para role="optional">
       <ulink url="&blfs-svn;/x/vulkan-loader.html">Vulkan-Loader</ulink>,
@@ -55,9 +60,9 @@
       <ulink url="&glfs-website;/shareddeps/ocl-icd.html">OCL-ICD</ulink>,
       <ulink url="&blfs-svn;/xfce/xfconf.html">Xfconf</ulink>,
       <ulink url="&blfs-svn;/multimedia/pulseaudio.html">PulseAudio</ulink>,
-      <ulink url="&arch-pkgs;/extra/x86_64/ddcutil/">ddcutil</ulink> and
-      <ulink url="&arch-pkgs;/extra/x86_64/directx-headers/">DirectX-Headers
-      </ulink>
+      <ulink url="&arch-pkgs;/extra/x86_64/ddcutil/">ddcutil</ulink>,
+      <ulink url="&arch-pkgs;/extra/x86_64/directx-headers/">DirectX-Headers</ulink>, and
+      <ulink url="&arch-pkgs;/extra/x86_64/efl/">EFL</ulink>
     </para>
 
   </sect2>
@@ -75,6 +80,7 @@ cd    build &amp;&amp;
 cmake -D CMAKE_INSTALL_PREFIX=/usr    \
       -D CMAKE_BUILD_TYPE=Release     \
       -D BUILD_FLASHFETCH=OFF         \
+      -D ENABLE_SYSTEM_YYJSON=ON      \
       -D PACKAGES_DISABLE_CHOCO=ON    \
       -D PACKAGES_DISABLE_MACPORTS=ON \
       -D PACKAGES_DISABLE_SCOOP=ON    \
@@ -105,6 +111,13 @@ make</userinput></screen>
       <parameter>-D BUILD_FLASHFETCH=OFF</parameter>: This switch disables
       building the historical flashfetch binary. If you need it for any reason,
       set this switch to <parameter>ON</parameter>.
+    </para>
+
+    <para>
+      <parameter>-D ENABLE_SYSTEM_YYJSON=ON</parameter>: This switch tells the
+      build system to link against the system install of yyjson instead of the
+      vendored copy. If you wish to use the vendored yyjson, set this switch to
+      <parameter>OFF</parameter>.
     </para>
 
     <para>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -40,6 +40,16 @@
     -->
 
     <listitem>
+      <para>May 15th, 2026</para>
+      <itemizedlist>
+        <listitem>
+          <para>[tox] - fastfetch: 2.62.1 -&gt; 2.63.1. Fixes
+          <ulink url="&slfs-issues;/703">#703</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>May 13th, 2026</para>
       <itemizedlist>
         <listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -99,7 +99,7 @@ version, so keep this at that. -->
 <!ENTITY ncdu-version                        "1.22">
 <!ENTITY ncompress-version                   "5.0">
 <!ENTITY neofetch-version                    "7.1.0">
-<!ENTITY fastfetch-version                   "2.62.1">
+<!ENTITY fastfetch-version                   "2.63.1">
 <!ENTITY rpmextract-version                  "1.0">
 <!ENTITY scdoc-version                       "1.11.4">
 <!ENTITY tmux-version                        "3.6a">


### PR DESCRIPTION
Changes to the page include the following:
- More consistent usage of serial commas and hyphens for compound adjectives
- Devendored yyjson
- EFL as an optional dependency