### PR TITLE
fastfetch: 2.63.1 -> 2.64.0. Fixes #738

### DIFF
--- a/general/genutils/fastfetch.xml
+++ b/general/genutils/fastfetch.xml
@@ -56,13 +56,19 @@
       <ulink url="&blfs-svn;/general/imagemagick.html">ImageMagick</ulink>,
       <ulink url="&arch-pkgs;/extra/x86_64/chafa/">Chafa</ulink>,
       <ulink url="&blfs-svn;/general/dbus.html">D-Bus</ulink>,
+      <ulink url="&blfs-svn;/general/lua.html">Lua</ulink>,
+      <ulink url="&blfs-svn;/multimedia/libva.html">libva</ulink>,
+      <ulink url="&blfs-svn;/x/libdrm.html">Libdrm</ulink>,
+      <ulink url="&blfs-svn;/gnome/dconf.html">DConf</ulink>,
       &opengl;,
       <ulink url="&glfs-website;/shareddeps/opencl-sdk.html">OpenCL-SDK</ulink>,
       <ulink url="&blfs-svn;/xfce/xfconf.html">Xfconf</ulink>,
       <ulink url="&blfs-svn;/multimedia/pulseaudio.html">PulseAudio</ulink>,
       <ulink url="&arch-pkgs;/extra/x86_64/ddcutil/">ddcutil</ulink>,
-      <ulink url="&arch-pkgs;/extra/x86_64/directx-headers/">DirectX-Headers</ulink>, and
-      <ulink url="&arch-pkgs;/extra/x86_64/efl/">EFL</ulink>
+      <ulink url="&arch-pkgs;/extra/x86_64/directx-headers/">DirectX-Headers</ulink>,
+      <ulink url="&arch-pkgs;/extra/x86_64/efl/">EFL</ulink>,
+      <ulink url="&arch-pkgs;/extra/x86_64/libvdpau/">libvdpau</ulink>, and
+      <ulink url="https://github.com/quickjs-ng/quickjs">QuickJS</ulink>
     </para>
 
   </sect2>
@@ -126,6 +132,12 @@ make</userinput></screen>
       package managers, only the ones that don't support Linux have been
       disabled. If you'd like to support these package managers, set their
       switches to <parameter>OFF</parameter>.
+    </para>
+
+    <para>
+      <parameter>-D ENABLE_{LUA,QUICKJS}=OFF</parameter>: Pass this switch if
+      you have one of these scripting languages installed and wish to disable
+      their use for format strings.
     </para>
 
   </sect2>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -40,6 +40,16 @@
     -->
 
     <listitem>
+      <para>June 4th, 2026</para>
+      <itemizedlist>
+        <listitem>
+          <para>[tox] - fastfetch: 2.63.1 -&gt; 2.64.0. Fixes
+          <ulink url="&slfs-issues;/738">#738</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>May 29th, 2026</para>
       <itemizedlist>
         <listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -99,7 +99,7 @@ version, so keep this at that. -->
 <!ENTITY ncdu-version                        "1.22">
 <!ENTITY ncompress-version                   "5.0">
 <!ENTITY neofetch-version                    "7.1.0">
-<!ENTITY fastfetch-version                   "2.63.1">
+<!ENTITY fastfetch-version                   "2.64.0">
 <!ENTITY rpmextract-version                  "1.0">
 <!ENTITY scdoc-version                       "1.11.4">
 <!ENTITY tmux-version                        "3.6b">


### PR DESCRIPTION
In addition to the new optional dependencies, I also added Libdrm and DConf, which are referenced in fastfetch's CMakeLists.txt.