### PR TITLE
fastfetch: 2.64.0 -> 2.64.2. Fixes #751

### DIFF
--- a/general/genutils/fastfetch.xml
+++ b/general/genutils/fastfetch.xml
@@ -87,6 +87,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr    \
       -D CMAKE_BUILD_TYPE=Release     \
       -D BUILD_FLASHFETCH=OFF         \
       -D ENABLE_SYSTEM_YYJSON=ON      \
+      -D PACKAGES_REMOVE_DISABLED=ON  \
       -D PACKAGES_DISABLE_CHOCO=ON    \
       -D PACKAGES_DISABLE_MACPORTS=ON \
       -D PACKAGES_DISABLE_SCOOP=ON    \
@@ -124,6 +125,12 @@ make</userinput></screen>
       build system to link against the system install of yyjson instead of the
       vendored copy. If you wish to use the vendored yyjson, set this switch to
       <parameter>OFF</parameter>.
+    </para>
+
+    <para>
+      <parameter>-D PACKAGES_REMOVE_DISABLED=ON</parameter>: This switch
+      removes detection code for disabled package managers, marginally reducing
+      binary size.
     </para>
 
     <para>

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -40,6 +40,16 @@
     -->
 
     <listitem>
+      <para>June 6th, 2026</para>
+      <itemizedlist>
+        <listitem>
+          <para>[tox] - fastfetch: 2.64.0 -&gt; 2.64.2. Fixes
+          <ulink url="&slfs-issues;/751">#751</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>June 4th, 2026</para>
       <itemizedlist>
         <listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -99,7 +99,7 @@ version, so keep this at that. -->
 <!ENTITY ncdu-version                        "1.22">
 <!ENTITY ncompress-version                   "5.0">
 <!ENTITY neofetch-version                    "7.1.0">
-<!ENTITY fastfetch-version                   "2.64.0">
+<!ENTITY fastfetch-version                   "2.64.2">
 <!ENTITY rpmextract-version                  "1.0">
 <!ENTITY scdoc-version                       "1.11.4">
 <!ENTITY tmux-version                        "3.6b">


### PR DESCRIPTION
Make use of the `PACKAGES_REMOVE_DISABLED` CMake option added in [2.64.1](https://github.com/fastfetch-cli/fastfetch/releases/tag/2.64.1).