### PR TITLE
Updated asio and intel-onevpl

### DIFF
--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -43,6 +43,12 @@
       <para>August 1st, 2026</para>
       <itemizedlist>
         <listitem>
+          <para>[Sicarine] - intel-onevpl: 26.2.3 -&gt; 26.2.4.</para>
+        </listitem>
+        <listitem>
+          <para>[Sicarine] - asio: 1-38-1 -&gt; 1-38-2.</para>
+        </listitem>
+        <listitem>
           <para>[zeckma] - SceneFX: 0.4.1 -&gt; 0.5. Fixes
           <ulink url="&slfs-issues;/806">#806</ulink>.</para>
         </listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -1,7 +1,7 @@
 <!-- GENERAL -->
 <!-- General Libraries -->
 <!ENTITY anthy-version                       "1:0.4-3">
-<!ENTITY asio-version                        "1-38-1">
+<!ENTITY asio-version                        "1-38-2">
 <!ENTITY capstone-version                    "5.0.9">
 <!ENTITY cglm-version                        "0.9.6">
 <!ENTITY cjson-version                       "1.7.19">
@@ -195,7 +195,7 @@ version, so keep this at that. -->
 <!ENTITY libdecor-version                    "0.2.5">
 <!ENTITY libspng-version                     "0.7.4">
 <!ENTITY libvpl-version                      "2.17.0">
-<!ENTITY intel-onevpl-version                "26.2.3">
+<!ENTITY intel-onevpl-version                "26.2.4">
 <!ENTITY xdg-desktop-portal-hyprland-version "1.3.12">
 <!-- Graphical Toolkits -->
 <!ENTITY printproto-version                  "1.0.5">


### PR DESCRIPTION
Minor version bump for both packages. onevpl bump is the Q2 quarterly release. Tested via OBS Studio. Seem to be running fine. Let me know if, in future, you would like me to open an issue first before submitting a pull request.