### PR TITLE
*: replace `-W no-dev` with `-W no-author`

### DIFF
--- a/emu/game-emu/dolphin.xml
+++ b/emu/game-emu/dolphin.xml
@@ -240,7 +240,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr        \
       -D CMAKE_POLICY_VERSION_MINIMUM=3.5 \
       -D ENABLE_TESTS=OFF                 \
       -D USE_SYSTEM_LIBMGBA=OFF           \
-      -G Ninja -W no-dev .. &amp;&amp;
+      -G Ninja -W no-author ..           &amp;&amp;
 
 ninja</userinput></screen>
 

--- a/emu/game-emu/pcsx2.xml
+++ b/emu/game-emu/pcsx2.xml
@@ -102,7 +102,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr       \
       -D USE_VULKAN=ON                   \
       -D WAYLAND_API=ON                  \
       -D X11_API=ON                      \
-      -W no-dev -G Ninja .. &amp;&amp;
+      -W no-author -G Ninja ..          &amp;&amp;
 ninja</userinput></screen>
 
     <para>

--- a/gaming/mc/prism-launcher.xml
+++ b/gaming/mc/prism-launcher.xml
@@ -103,7 +103,7 @@ cd    build &amp;&amp;
 CXXFLAGS+=" -Wno-sfinae-incomplete"  \
 cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D CMAKE_BUILD_TYPE=Release    \
-      -W no-dev -G Ninja .. &amp;&amp;
+      -W no-author -G Ninja ..      &amp;&amp;
 
 ninja</userinput></screen>
 

--- a/gaming/ttd/openttd.xml
+++ b/gaming/ttd/openttd.xml
@@ -81,7 +81,7 @@ cd    build &amp;&amp;
 
 cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D CMAKE_BUILD_TYPE=Release    \
-      -W no-dev -G Ninja .. &amp;&amp;
+      -W no-author -G Ninja ..      &amp;&amp;
 
 ninja</userinput></screen>
 

--- a/general/genlib/capstone.xml
+++ b/general/genlib/capstone.xml
@@ -61,7 +61,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr \
       -D CMAKE_BUILD_TYPE=Release  \
       -D BUILD_STATIC_LIBS=OFF     \
       -D BUILD_SHARED_LIBS=ON      \
-      -W no-dev -G Ninja .. &amp;&amp;
+      -W no-author -G Ninja ..    &amp;&amp;
 ninja</userinput></screen>
 
     <para>

--- a/general/genlib/hidapi.xml
+++ b/general/genlib/hidapi.xml
@@ -81,7 +81,7 @@ cd    build &amp;&amp;
 cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D CMAKE_BUILD_TYPE=Release    \
       -D CMAKE_SKIP_INSTALL_RPATH=ON \
-      -W no-dev -G Ninja .. &amp;&amp;
+      -W no-author -G Ninja ..      &amp;&amp;
 ninja</userinput></screen>
 
     <para>

--- a/general/genlib/libdatachannel.xml
+++ b/general/genlib/libdatachannel.xml
@@ -99,7 +99,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr        \
       -D USE_SYSTEM_SRTP=1                \
       -D NO_EXAMPLES=1                    \
       -D NO_TESTS=1                       \
-      -Wno-dev -G Ninja .. &amp;&amp;
+      -W no-author -G Ninja ..           &amp;&amp;
 
 ninja</userinput></screen>
 

--- a/general/genlib/libime.xml
+++ b/general/genlib/libime.xml
@@ -86,7 +86,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D CMAKE_SKIP_INSTALL_RPATH=ON \
       -D BUILD_SHARED_LIBS=ON        \
       -D ENABLE_TEST=OFF             \
-      -Wno-dev .. &amp;&amp;
+      -W no-author ..               &amp;&amp;
 
 make</userinput></screen>
 

--- a/general/genlib/plutosvg.xml
+++ b/general/genlib/plutosvg.xml
@@ -73,7 +73,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr  \
       -D CMAKE_BUILD_TYPE=Release   \
       -D BUILD_SHARED_LIBS=ON       \
       -D PLUTOVG_BUILD_EXAMPLES=OFF \
-      -W no-dev -G Ninja .. &amp;&amp;
+      -W no-author -G Ninja ..     &amp;&amp;
 ninja</userinput></screen>
 
     <para>
@@ -92,9 +92,9 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D CMAKE_BUILD_TYPE=Release    \
       -D BUILD_SHARED_LIBS=ON        \
       -D PLUTOSVG_BUILD_EXAMPLES=OFF \
-      -W no-dev -G Ninja             \
+      -W no-author -G Ninja          \
       -B svg-build                   \
-      plutosvg-&plutosvg-version; &amp;&amp;
+      plutosvg-&plutosvg-version;   &amp;&amp;
 ninja -C svg-build</userinput></screen>
 
     <para>

--- a/general/genlib/yajl.xml
+++ b/general/genlib/yajl.xml
@@ -75,7 +75,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D CMAKE_BUILD_TYPE=Release    \
       -D BUILD_SHARED_LIBS=ON        \
       -D CMAKE_SKIP_INSTALL_RPATH=ON \
-      -W no-dev -G Ninja .. &amp;&amp;
+      -W no-author -G Ninja ..      &amp;&amp;
 
 ninja</userinput></screen>
 

--- a/general/genutils/cmark.xml
+++ b/general/genutils/cmark.xml
@@ -58,7 +58,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D CMAKE_BUILD_TYPE=Release    \
       -D CMAKE_SKIP_INSTALL_RPATH=ON \
       -D BUILD_SHARED_LIBS=ON        \
-      -W no-dev -G Ninja .. &amp;&amp;
+      -W no-author -G Ninja ..      &amp;&amp;
 
 ninja</userinput></screen>
 

--- a/general/genutils/fluidsynth.xml
+++ b/general/genutils/fluidsynth.xml
@@ -114,7 +114,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr             \
       -D CMAKE_BUILD_TYPE=Release              \
       -D CMAKE_SKIP_INSTALL_RPATH=ON           \
       -D FLUID_DAEMON_ENV_FILE=/etc/fluidsynth \
-      -W no-dev -G Ninja .. &amp;&amp;
+      -W no-author -G Ninja ..                &amp;&amp;
 ninja</userinput></screen>
 
     <para>To run the tests, issue <command>ninja check</command>.</para>

--- a/general/genutils/monero.xml
+++ b/general/genutils/monero.xml
@@ -158,7 +158,7 @@ cd    build &amp;&amp;
 cmake -D CMAKE_INSTALL_PREFIX=/usr \
       -D CMAKE_BUILD_TYPE=Release  \
       -D BUILD_GUI_DEPS=ON         \
-      -G Ninja -W no-dev .. &amp;&amp;
+      -G Ninja -W no-author ..    &amp;&amp;
 
 ninja</userinput></screen>
 

--- a/general/mm-lib/noise-suppression.xml
+++ b/general/mm-lib/noise-suppression.xml
@@ -70,7 +70,7 @@ cd    build &amp;&amp;
 cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D CMAKE_BUILD_TYPE=Release    \
       -D CMAKE_SKIP_INSTALL_RPATH=ON \
-      -W no-dev -G Ninja .. &amp;&amp;
+      -W no-author -G Ninja ..      &amp;&amp;
 ninja</userinput></screen>
 
     <para>

--- a/general/mm-lib/sdl.xml
+++ b/general/mm-lib/sdl.xml
@@ -58,7 +58,7 @@ cd    build &amp;&amp;
 cmake -D CMAKE_INSTALL_PREFIX=/usr \
       -D CMAKE_BUILD_TYPE=RELEASE  \
       -D SDL12TESTS=OFF            \
-      -W no-dev -G Ninja .. &amp;&amp;
+      -W no-author -G Ninja ..    &amp;&amp;
 ninja</userinput></screen>
 
     <para>

--- a/graph/app/libvpl-tools.xml
+++ b/graph/app/libvpl-tools.xml
@@ -71,7 +71,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr     \
       -D CMAKE_BUILD_TYPE=Release      \
       -D CMAKE_SKIP_INSTALL_RPATH=ON   \
       -D BUILD_TESTS=ON                \
-      -W no-dev ..                     &amp;&amp;
+      -W no-author ..                 &amp;&amp;
 make</userinput></screen>
 
     <para>

--- a/graph/app/obs-studio.xml
+++ b/graph/app/obs-studio.xml
@@ -272,7 +272,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr             \
       -D ENABLE_JACK=OFF                       \
       -D ENABLE_NEW_MPEGTS_OUTPUT=OFF          \
       -D OBS_COMPILE_DEPRECATION_AS_WARNING=ON \
-      -G Ninja -Wno-dev .. &amp;&amp;
+      -G Ninja -W no-author ..                &amp;&amp;
 
 ninja</userinput></screen>
 

--- a/graph/fcitx/fcitx5-anthy.xml
+++ b/graph/fcitx/fcitx5-anthy.xml
@@ -60,7 +60,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D CMAKE_BUILD_TYPE=Release    \
       -D CMAKE_SKIP_INSTALL_RPATH=ON \
       -D ENABLE_TEST=OFF             \
-      -Wno-dev .. &amp;&amp;
+      -W no-author ..               &amp;&amp;
 
 make</userinput></screen>
 

--- a/graph/fcitx/fcitx5-chinese-addons.xml
+++ b/graph/fcitx/fcitx5-chinese-addons.xml
@@ -81,7 +81,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D ENABLE_OPENCC=OFF           \
       -D ENABLE_BROWSER=OFF          \
       -D ENABLE_CLOUDPINYIN=OFF      \
-      -Wno-dev .. &amp;&amp;
+      -W no-author ..               &amp;&amp;
 
 make</userinput></screen>
 

--- a/graph/fcitx/fcitx5-configtool.xml
+++ b/graph/fcitx/fcitx5-configtool.xml
@@ -69,7 +69,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D CMAKE_BUILD_TYPE=Release    \
       -D CMAKE_SKIP_INSTALL_RPATH=ON \
       -D ENABLE_KCM=OFF              \
-      -Wno-dev .. &amp;&amp;
+      -W no-author ..               &amp;&amp;
 
 make</userinput></screen>
 

--- a/graph/fcitx/fcitx5-gtk.xml
+++ b/graph/fcitx/fcitx5-gtk.xml
@@ -66,7 +66,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D ENABLE_GTK2_IM_MODULE=OFF   \
       -D ENABLE_GTK3_IM_MODULE=ON    \
       -D ENABLE_GTK4_IM_MODULE=ON    \
-      -Wno-dev .. &amp;&amp;
+      -W no-author ..               &amp;&amp;
 
 make</userinput></screen>
 

--- a/graph/fcitx/fcitx5-lua.xml
+++ b/graph/fcitx/fcitx5-lua.xml
@@ -59,7 +59,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D CMAKE_BUILD_TYPE=Release    \
       -D CMAKE_SKIP_INSTALL_RPATH=ON \
       -D ENABLE_TEST=OFF             \
-      -Wno-dev .. &amp;&amp;
+      -W no-author ..               &amp;&amp;
 
 make</userinput></screen>
 

--- a/graph/fcitx/fcitx5-m17n.xml
+++ b/graph/fcitx/fcitx5-m17n.xml
@@ -59,7 +59,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D CMAKE_BUILD_TYPE=Release    \
       -D CMAKE_SKIP_INSTALL_RPATH=ON \
       -D ENABLE_TEST=OFF             \
-      -Wno-dev .. &amp;&amp;
+      -W no-author ..               &amp;&amp;
 
 make</userinput></screen>
 

--- a/graph/fcitx/fcitx5-qt.xml
+++ b/graph/fcitx/fcitx5-qt.xml
@@ -71,7 +71,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D ENABLE_QT4=OFF              \
       -D ENABLE_QT5=OFF              \
       -D ENABLE_QT6=ON               \
-      -Wno-dev .. &amp;&amp;
+      -W no-author ..               &amp;&amp;
 
 make</userinput></screen>
 

--- a/graph/fcitx/fcitx5-table-extra.xml
+++ b/graph/fcitx/fcitx5-table-extra.xml
@@ -59,7 +59,7 @@ cd    build &amp;&amp;
 cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D CMAKE_BUILD_TYPE=Release    \
       -D CMAKE_SKIP_INSTALL_RPATH=ON \
-      -Wno-dev .. &amp;&amp;
+      -W no-author ..               &amp;&amp;
 
 make</userinput></screen>
 

--- a/graph/fcitx/fcitx5.xml
+++ b/graph/fcitx/fcitx5.xml
@@ -107,7 +107,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D CMAKE_BUILD_TYPE=Release    \
       -D CMAKE_SKIP_INSTALL_RPATH=ON \
       -D ENABLE_TEST=OFF             \
-      -Wno-dev .. &amp;&amp;
+      -W no-author ..               &amp;&amp;
 
 make</userinput></screen>
 

--- a/graph/lib/glfw.xml
+++ b/graph/lib/glfw.xml
@@ -71,7 +71,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr \
       -D BUILD_SHARED_LIBS=ON      \
       -D GLFW_BUILD_EXAMPLES=OFF   \
       -D GLFW_BUILD_TESTS=OFF      \
-      -W no-dev -G Ninja .. &amp;&amp;
+      -W no-author -G Ninja ..    &amp;&amp;
 ninja</userinput></screen>
 
     <para>

--- a/graph/lib/intel-mediasdk.xml
+++ b/graph/lib/intel-mediasdk.xml
@@ -92,7 +92,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr        \
       -D ENABLE_WAYLAND=ON                \
       -D ENABLE_X11_DRI3=ON               \
       -D MFX_APPS_DIR=/usr/lib/mfx        \
-      -W no-dev ..                        &amp;&amp;
+      -W no-author ..                    &amp;&amp;
 make</userinput></screen>
 
     <para>

--- a/graph/lib/intel-onevpl.xml
+++ b/graph/lib/intel-onevpl.xml
@@ -68,7 +68,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D CMAKE_SKIP_INSTALL_RPATH=ON \
       -D BUILD_TESTS=OFF             \
       -D MFX_ENABLE_AENC=ON          \
-      -W no-dev ..                   &amp;&amp;
+      -W no-author ..               &amp;&amp;
 make</userinput></screen>
 
     <para>

--- a/graph/lib/libvpl.xml
+++ b/graph/lib/libvpl.xml
@@ -74,7 +74,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr     \
       -D CMAKE_SKIP_INSTALL_RPATH=ON   \
       -D BUILD_EXAMPLES=OFF            \
       -D BUILD_TESTS=ON                \
-      -W no-dev ..                     &amp;&amp;
+      -W no-author ..                 &amp;&amp;
 make</userinput></screen>
 
     <para>

--- a/graph/tk/xcb-imdkit.xml
+++ b/graph/tk/xcb-imdkit.xml
@@ -65,7 +65,7 @@ cd    build &amp;&amp;
 cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D CMAKE_BUILD_TYPE=Release    \
       -D CMAKE_SKIP_INSTALL_RPATH=ON \
-      -W no-dev -G Ninja .. &amp;&amp;
+      -W no-author -G Ninja ..      &amp;&amp;
 ninja</userinput></screen>
 
     <para>

--- a/wm/hypr/hyprland.xml
+++ b/wm/hypr/hyprland.xml
@@ -150,7 +150,7 @@ cmake -D CMAKE_INSTALL_PREFIX=/usr   \
       -D CMAKE_BUILD_TYPE=Release    \
       -D CMAKE_SKIP_INSTALL_RPATH=ON \
       -D BUILD_TESTING=OFF           \
-      -W no-dev -G Ninja .. &amp;&amp;
+      -W no-author -G Ninja ..      &amp;&amp;
 ninja</userinput></screen>
 
     <para>

--- a/wm/hypr/hyprlib.xml
+++ b/wm/hypr/hyprlib.xml
@@ -184,7 +184,7 @@ echo "Building $packagedir"
               -D INSTALL_QML_PREFIX=/lib/qt6/qml \
               -D DISABLE_TESTS=ON                \
               -D BUILD_TESTING=OFF               \
-              -W no-dev -G Ninja ..
+              -W no-author -G Ninja ..
     ;;
   esac
 


### PR DESCRIPTION
CMake 4.4 emits a deprecation warning for `-W no-dev` suggesting this change.

See also:
* <https://github.com/lfs-book/blfs/commit/eaa0a5cc234def45dc775fa6c3684622305883dd>
* <https://github.com/glfs-book/glfs/pull/519>