### PR TITLE
Glaze: 7.9.1 -> 8.0.0. Fixes #867

### DIFF
--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -40,6 +40,16 @@
     -->
 
     <listitem>
+      <para>August 7th, 2026</para>
+      <itemizedlist>
+        <listitem>
+          <para>[tox] - Glaze: 7.9.1 -&gt; 8.0.0. Fixes
+          <ulink url="&slfs-issues;/867">#867</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>August 2nd, 2026</para>
       <itemizedlist>
         <listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -7,7 +7,7 @@
 <!ENTITY cjson-version                       "1.7.19">
 <!ENTITY enet-version                        "1.3.18">
 <!ENTITY fuse2-version                       "2.9.9">
-<!ENTITY glaze-version                       "7.9.1">
+<!ENTITY glaze-version                       "8.0.0">
 <!ENTITY hidapi-version                      "0.15.0">
 <!ENTITY iniparser-version                   "4.2.6">
 <!ENTITY jemalloc-version                    "5.3.1">


### PR DESCRIPTION
This currently breaks the Hyprland build. That will be fixed in the patch updating Hyprland.