### PR TITLE
Hyprland: 0.56.1 -> 0.56.2. Fixes #871

### DIFF
--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -40,6 +40,16 @@
     -->
 
     <listitem>
+      <para>August 7th, 2026</para>
+      <itemizedlist>
+        <listitem>
+          <para>[tox] - Hyprland: 0.56.1 -&gt; 0.56.2. Fixes
+          <ulink url="&slfs-issues;/871">#871</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>August 2nd, 2026</para>
       <itemizedlist>
         <listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -248,7 +248,7 @@ version, so keep this at that. -->
 <!ENTITY hyprtoolkit-version                 "0.5.4">
 <!ENTITY hyprland-qt-support-version         "0.1.0">
 <!ENTITY hyprland-guiutils-version           "0.2.2">
-<!ENTITY hyprland-version                    "0.56.1">
+<!ENTITY hyprland-version                    "0.56.2">
 <!ENTITY hypr-udis86-version                 "5336633af70f3917760a6d441ff02d93477b0c86">
 <!-- i3 -->
 <!ENTITY i3-version                          "4.25.1">

--- a/wm/hypr/hyprland.xml
+++ b/wm/hypr/hyprland.xml
@@ -129,8 +129,8 @@ mv -T udis86-&hypr-udis86-version; subprojects/udis86</userinput></screen>
       Ensure that the installed version of Glaze can be used:
     </para>
 
-<screen><userinput remap="pre">sed -i "s/glaze\ [0-9][0-9.]*...&lt;[0-9][0-9.]*/glaze/" \
-  hyprpm/CMakeLists.txt</userinput></screen>
+<screen><userinput remap="pre">find . -name CMakeLists.txt |
+    xargs sed -i 's/glaze [0-9][0-9.]*\.\.\.&lt;[0-9][0-9.]*/glaze/'</userinput></screen>
 
     <important><para>
       If Glaze is installed and you haven't run the above commands, Hyprland,


### PR DESCRIPTION
The Glaze `sed` should now be more future-proof.